### PR TITLE
feat: match spec

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -3,22 +3,23 @@
 const ipfsProvider = require('ipfs-provider')
 const meow = require('meow')
 const cohost = require('.')
+const ora = require('ora')
 const cli = meow(`
   Usage
-    $ ipfs-cohost <domain 1> <domain 2>...
+    $ ipfs-cohost <domain>...
+    $ ipfs-cohost add <domain>...
+    $ ipfs-cohost rm <domain>...
+    $ ipfs-cohost ls [domain]...
+    $ ipfs-cohost sync
+    $ ipfs-cohost gc [n]
 
   Example
     $ ipfs-cohost docs.ipfs.io cid.ipfs.io
 
   Options
-    --no-pin, Find the cumlative sizes but dont pin them
     --silent, -s  Just do your job
 `, {
   flags: {
-    pin: {
-      type: 'boolean',
-      default: true
-    },
     silent: {
       type: 'boolean',
       default: false,
@@ -27,25 +28,93 @@ const cli = meow(`
   }
 })
 
-/*
-{
-  input: ['domain.com', 'otherthing.org'],
-  flags: {pin: true, silent: false},
-  ...
+async function add (ipfs, input, silent) {
+  let spinner
+  for (const domain of input) {
+    if (!silent) spinner = ora({ text: `Cohosting ${domain}...` }).start()
+    await cohost.add(ipfs, domain)
+    if (!silent) spinner.succeed(`${domain} cohosted!`)
+  }
 }
-*/
+
+async function rm (ipfs, input, silent) {
+  let spinner
+  for (const domain of input) {
+    if (!silent) spinner = ora({ text: `Stopping to cohost ${domain}...` }).start()
+    await cohost.rm(ipfs, domain)
+    if (!silent) spinner.succeed(`${domain} no longer cohosted!`)
+  }
+}
+
+async function ls (ipfs, input) {
+  if (input.length > 0) {
+    for (const domain of input) {
+      const snapshots = await cohost.ls(ipfs, domain)
+      console.log(`Snapshots for ${domain}:`)
+      snapshots.forEach(n => console.log(` - ${n}`))
+      console.log('')
+    }
+
+    return
+  }
+
+  console.log('Cohosted domains:')
+  const domains = await cohost.ls(ipfs)
+  domains.forEach(n => console.log(` - ${n}`))
+}
+
+async function sync (ipfs, silent) {
+  let spinner
+  if (!silent) spinner = ora({ text: 'Syncing snapshots...' }).start()
+  await cohost.sync(ipfs)
+  if (!silent) spinner.succeed('Snapshots synced!')
+}
+
+async function gc (ipfs, input, silent) {
+  let num = null
+  if (input.length > 0) num = parseInt(input[0], 10)
+
+  let spinner
+  if (!silent) spinner = ora({ text: 'Cleaning cohosted websites...' }).start()
+  await cohost.gc(ipfs, num)
+  if (!silent) spinner.succeed('Cohosted websites cleaned!')
+}
 
 async function run () {
   if (cli.input.length === 0) {
     return cli.showHelp()
   }
+
+  const cmd = cli.input.shift()
+  const input = cli.input
+
   const { ipfs, provider } = await getIpfs()
+
   try {
-    await cohost(ipfs, provider, cli.input, cli.flags)
+    switch (cmd) {
+      case 'add':
+        await add(ipfs, input, cli.flags.silent)
+        break
+      case 'rm':
+        await rm(ipfs, input, cli.flags.silent)
+        break
+      case 'ls':
+        await ls(ipfs, input)
+        break
+      case 'sync':
+        await sync(ipfs, cli.flags.silent)
+        break
+      case 'gc':
+        await gc(ipfs, input, cli.flags.silent)
+        break
+      default:
+        await add(ipfs, input.concat(cmd), cli.flags.silent)
+    }
   } catch (error) {
     console.error(error.message || error)
     process.exit(-1)
   }
+
   if (provider === 'JS_IPFS' && !cli.flags.pin) {
     await ipfs.stop()
     process.exit()

--- a/examples/no-pin.sh
+++ b/examples/no-pin.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-../bin.js `cat dnslink-domains.txt` --no-pin
+../bin.js `cat dnslink-domains.txt`

--- a/index.js
+++ b/index.js
@@ -1,59 +1,75 @@
-const ora = require('ora')
-const prettyBytes = require('pretty-bytes')
+function getTimestamp () {
+  return new Date().toISOString()
+    .replace(/:/g, '')
+    .replace('T', '_')
+    .split('.')[0]
+}
 
-module.exports = cohost
+async function add (ipfs, domain) {
+  const cid = await ipfs.resolve(`/ipns/${domain}`)
+  const path = `/cohosting/${domain}`
 
-async function cohost (ipfs, provider, input, flags) {
-  const log = logger.bind(null, flags.silent)
-  const longestDomain = input.reduce((a, b) => a.length > b.length ? a.length : b.length, '')
-  log('🔌 Using', provider === 'IPFS_HTTP_API' ? 'local ipfs daemon via http api' : 'js-ipfs node')
-  if (input.length > 1) {
-    log(`🔍 Finding DNSLinks for ${input.length} domains`)
+  // Create with parents if it is the first time
+  await ipfs.files.mkdir(path, { parents: true })
+  const dirs = await ipfs.files.ls(path)
+  const latest = dirs.map(file => file.name).sort().pop()
+
+  if (latest) {
+    const path = `/cohosting/${domain}/${latest}`
+    const stat = await ipfs.files.stat(path)
+
+    if (`/ipfs/${stat.hash}` === cid) {
+      await ipfs.files.mv([path, `/cohosting/${domain}/${getTimestamp()}`])
+      return
+    }
   }
-  const results = []
-  for (const domain of input) {
-    const spinner = getSpinner(domain)
-    try {
-      const address = await ipfs.dns(domain)
-      const cid = address.slice(6) // trim off the /ipfs/ prefix... TODO: js-ipfs should deal.
-      const stat = await ipfs.object.stat(cid)
-      results.push({ domain, cid, stat })
-      spinner.stop()
-      log('🔗', domain.padEnd(longestDomain), cid, prettyBytes(stat.CumulativeSize))
-    } catch (error) {
-      if (error.message === 'could not resolve name' || error.code === 'ENODATA') {
-        log('⚠️ ', domain.padEnd(longestDomain), 'has no DNSLink TXT record')
-      } else if (error.message === 'not a valid domain name' || error.code === 'ENOTFOUND') {
-        log('⚠️ ', domain.padEnd(longestDomain), 'is not a valid domain')
-      } else {
-        log('⚠️ ', domain.padEnd(longestDomain), error.message || error)
+
+  await ipfs.files.cp([cid, `/cohosting/${domain}/${getTimestamp()}`])
+}
+
+async function rm (ipfs, domain) {
+  await ipfs.files.rm(`/cohosting/${domain}`, { recursive: true })
+}
+
+async function ls (ipfs, domain = null) {
+  let path = '/cohosting'
+  if (domain) path += `/${domain}`
+
+  return (await ipfs.files.ls(path)).map(file => file.name).sort()
+}
+
+async function sync (ipfs) {
+  await ipfs.files.stat('/cohosting')
+  const files = await ipfs.files.ls('/cohosting')
+  const domains = files.map(file => file.name)
+
+  for (const domain of domains) {
+    await add(ipfs, domain)
+  }
+}
+
+async function gc (ipfs, count = null) {
+  const domains = await ls(ipfs)
+
+  for (const domain of domains) {
+    if (count !== null) {
+      const snapshots = await ls(ipfs, domain)
+      const toRemove = snapshots.reverse().slice(count)
+
+      for (const snap of toRemove) {
+        await ipfs.files.rm(`/cohosting/${domain}/${snap}`, { recursive: true })
       }
-    }
-  }
-  const totalBytes = results.map(x => x.stat.CumulativeSize).reduce((a, b) => a + b, 0)
-  log(`📦 Total size`, prettyBytes(totalBytes), `for ${results.length} domains`)
-
-  if (flags.pin) {
-    for (const res of results) {
-      const spinner = getSpinner(`Pinning ${res.domain}`)
-      await ipfs.pin.add(res.cid)
-      spinner.stop()
-      log(`📍 Pinned ${res.domain}`)
-    }
-    if (results.length > 0) {
-      log(`🤝 Co-hosting ${results.length === 1 ? results[0].domain : `${results.length} domains`} via IPFS.`)
-    }
-    if (provider === 'JS_IPFS') {
-      log(`💡 Leave this command running to continue co-hosting`)
+    } else {
+      await rm(ipfs, domain)
+      await ipfs.files.mkdir(`/cohosting/${domain}`, { parents: true })
     }
   }
 }
 
-function logger (silent, ...args) {
-  if (silent) return
-  console.log(args.join(' '))
-}
-
-function getSpinner (text) {
-  return ora({ text: ` ${text}`, spinner: 'dots' }).start()
+module.exports = {
+  add,
+  rm,
+  ls,
+  sync,
+  gc
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,41 +25,41 @@
       }
     },
     "@hapi/accept": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-3.2.2.tgz",
-      "integrity": "sha512-UtXlTT59srtMr7ZRBzK2CvyWqFwlf78hPt9jEXqkwfbwiwRH1PRv/qkS8lgr5ZyoG6kfpU3xTgt2X91Yfe/6Yg==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-3.2.3.tgz",
+      "integrity": "sha512-qEzsOJkCAJZxwj3iF83bSG9Lxy8Bpbrt8mRLNdvSALT6vlU2cYh6ZEHKEZPy4h/Mo31Su3j0rJgFF91+W1RWDQ==",
       "requires": {
         "@hapi/boom": "7.x.x",
-        "@hapi/hoek": "6.x.x"
+        "@hapi/hoek": "8.x.x"
       }
     },
     "@hapi/address": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.0.0.tgz",
-      "integrity": "sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.2.tgz",
+      "integrity": "sha512-O4QDrx+JoGKZc6aN64L04vqa7e41tIiLU+OvKdcYaEMP97UttL0f9GIi9/0A4WAMx0uBd6SidDIhktZhgOcN8Q=="
     },
     "@hapi/ammo": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-3.1.0.tgz",
-      "integrity": "sha512-iFQBEfm3WwWy8JdPQ8l6qXVLPtzmjITVfaxwl6dfoP8kKv6i2Uk43Ax+ShkNfOVyfEnNggqL2IyZTY3DaaRGNg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-3.1.1.tgz",
+      "integrity": "sha512-NYFK27VSPGyQ/KmOQedpQH4PSjE7awLntepX68vrYtRvuJO21W1kX0bK2p3C+6ltUwtCQSvmNT8a4uMVAysC6Q==",
       "requires": {
-        "@hapi/hoek": "6.x.x"
+        "@hapi/hoek": "8.x.x"
       }
     },
     "@hapi/b64": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-4.2.0.tgz",
-      "integrity": "sha512-hmfPC1aF7cP21489A/IWPC3s1GE+1eAteVwFcOWLwj0Pky8eHgvrXPSSko2IeCpxqOdZhYw71IFN8xKPdv3CtQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-4.2.1.tgz",
+      "integrity": "sha512-zqHpQuH5CBMw6hADzKfU/IGNrxq1Q+/wTYV+OiZRQN9F3tMyk+9BUMeBvFRMamduuqL8iSp62QAnJ+7ATiYLWA==",
       "requires": {
-        "@hapi/hoek": "6.x.x"
+        "@hapi/hoek": "8.x.x"
       }
     },
     "@hapi/boom": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.2.tgz",
-      "integrity": "sha512-T2CYcTI0AqSvC6YC7keu/fh9LVSMzfoMLharBnPbOwmc+Cexj9joIc5yNDKunaxYq9LPuOwMS0f2B3S1tFQUNw==",
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
+      "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
       "requires": {
-        "@hapi/hoek": "6.x.x"
+        "@hapi/hoek": "8.x.x"
       }
     },
     "@hapi/bounce": {
@@ -69,13 +69,6 @@
       "requires": {
         "@hapi/boom": "7.x.x",
         "@hapi/hoek": "8.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.1.0.tgz",
-          "integrity": "sha512-b1J4jxYnW+n6lC91V6Pqg9imP9BZq0HNCeM+3sbXg05rQsE9cGYrKFpZjyztVesGmNRE6R+QaEoWGATeIiUVjA=="
-        }
       }
     },
     "@hapi/bourne": {
@@ -84,32 +77,46 @@
       "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA=="
     },
     "@hapi/call": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-5.1.0.tgz",
-      "integrity": "sha512-CiVEXjD/jiIHBqufBW3pdedshEMjRmHtff7m1puot8j4MUmuKRbLlh0DB8fv6QqH/7/55pH1qgFj300r0WpyMw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-5.1.1.tgz",
+      "integrity": "sha512-M6fC+9+K/ZB4hIdVQ8i0kc/6J5PWlW3PEWYKAAZpw0sk+28LiRTSF8BjOWwmiIjZWWs42AnEIiFJA0YrvcDnlw==",
       "requires": {
         "@hapi/boom": "7.x.x",
-        "@hapi/hoek": "6.x.x"
+        "@hapi/hoek": "8.x.x"
       }
     },
     "@hapi/catbox": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-10.2.1.tgz",
-      "integrity": "sha512-u13BXlnmmrNUZssjTriRVTLuk6I/yUy5C1/Pia1+E2cpfd7o2/jmEvYdFgeS0Ft9QTz7WWhpXKlrguARUuohhQ==",
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-10.2.3.tgz",
+      "integrity": "sha512-kN9hXO4NYyOHW09CXiuj5qW1syc/0XeVOBsNNk0Tz89wWNQE5h21WF+VsfAw3uFR8swn/Wj3YEVBnWqo82m/JQ==",
       "requires": {
         "@hapi/boom": "7.x.x",
-        "@hapi/hoek": "6.x.x",
-        "@hapi/joi": "15.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/joi": "16.x.x",
         "@hapi/podium": "3.x.x"
+      },
+      "dependencies": {
+        "@hapi/joi": {
+          "version": "16.1.7",
+          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.7.tgz",
+          "integrity": "sha512-anaIgnZhNooG3LJLrTFzgGALTiO97zRA1UkvQHm9KxxoSiIzCozB3RCNCpDnfhTJD72QlrHA8nwGmNgpFFCIeg==",
+          "requires": {
+            "@hapi/address": "^2.1.2",
+            "@hapi/formula": "^1.2.0",
+            "@hapi/hoek": "^8.2.4",
+            "@hapi/pinpoint": "^1.0.2",
+            "@hapi/topo": "^3.1.3"
+          }
+        }
       }
     },
     "@hapi/catbox-memory": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-4.1.0.tgz",
-      "integrity": "sha512-libCGyufOZaJu6uE9nVXw/u8tqOt4ifNIrOSAsDjzS+af3vPJyid8faOICqKCAh3E338UAsUe5AeYdezdsmtpg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-4.1.1.tgz",
+      "integrity": "sha512-T6Hdy8DExzG0jY7C8yYWZB4XHfc0v+p1EGkwxl2HoaPYAmW7I3E59M/IvmSVpis8RPcIoBp41ZpO2aZPBpM2Ww==",
       "requires": {
         "@hapi/boom": "7.x.x",
-        "@hapi/hoek": "6.x.x"
+        "@hapi/hoek": "8.x.x"
       }
     },
     "@hapi/content": {
@@ -121,9 +128,9 @@
       }
     },
     "@hapi/cryptiles": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-4.2.0.tgz",
-      "integrity": "sha512-P+ioMP1JGhwDOKPRuQls6sT/ln6Fk+Ks6d90mlBi6HcOu5itvdUiFv5Ynq2DvLadPDWaA43lwNxkfZrjE9s2MA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-4.2.1.tgz",
+      "integrity": "sha512-XoqgKsHK0l/VpqPs+tr6j6vE+VQ3+2bkF2stvttmc7xAOf1oSAwHcJ0tlp/6MxMysktt1IEY0Csy3khKaP9/uQ==",
       "requires": {
         "@hapi/boom": "7.x.x"
       }
@@ -133,10 +140,15 @@
       "resolved": "https://registry.npmjs.org/@hapi/file/-/file-1.0.0.tgz",
       "integrity": "sha512-Bsfp/+1Gyf70eGtnIgmScvrH8sSypO3TcK3Zf0QdHnzn/ACnAkI6KLtGACmNRPEzzIy+W7aJX5E+1fc9GwIABQ=="
     },
+    "@hapi/formula": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-1.2.0.tgz",
+      "integrity": "sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA=="
+    },
     "@hapi/hapi": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-18.3.1.tgz",
-      "integrity": "sha512-gBiU9isWWezrg0ucX95Ph6AY6fUKZub3FxKapaleoFBJDOUcxTYiQR6Lha2zvHalIFoTl3K04O3Yr/5pD17QkQ==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-18.4.0.tgz",
+      "integrity": "sha512-uk9zqknRLcNVQKgrPURm85DqkdroWP8eDRekh/IPoKvC4VjdZSn6EH2eUriOwyud/CldeBS3HDIJ/PtRj3VxDQ==",
       "requires": {
         "@hapi/accept": "3.x.x",
         "@hapi/ammo": "3.x.x",
@@ -146,7 +158,7 @@
         "@hapi/catbox": "10.x.x",
         "@hapi/catbox-memory": "4.x.x",
         "@hapi/heavy": "6.x.x",
-        "@hapi/hoek": "6.x.x",
+        "@hapi/hoek": "8.x.x",
         "@hapi/joi": "15.x.x",
         "@hapi/mimos": "4.x.x",
         "@hapi/podium": "3.x.x",
@@ -159,37 +171,58 @@
       }
     },
     "@hapi/heavy": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-6.2.0.tgz",
-      "integrity": "sha512-tzGU9cElY0IxRBudGB7tLFkdpBD8XQPfd6G7DSOnvHRK+q96UHGHn4t59Yd7kDpVucNkErWWYarsGx2KmKPkXA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-6.2.2.tgz",
+      "integrity": "sha512-PY1dCCO6dsze7RlafIRhTaGeyTgVe49A/lSkxbhKGjQ7x46o/OFf7hLiRqTCDh3atcEKf6362EaB3+kTUbCsVA==",
       "requires": {
         "@hapi/boom": "7.x.x",
-        "@hapi/hoek": "6.x.x",
-        "@hapi/joi": "15.x.x"
+        "@hapi/hoek": "8.x.x",
+        "@hapi/joi": "16.x.x"
+      },
+      "dependencies": {
+        "@hapi/joi": {
+          "version": "16.1.7",
+          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.7.tgz",
+          "integrity": "sha512-anaIgnZhNooG3LJLrTFzgGALTiO97zRA1UkvQHm9KxxoSiIzCozB3RCNCpDnfhTJD72QlrHA8nwGmNgpFFCIeg==",
+          "requires": {
+            "@hapi/address": "^2.1.2",
+            "@hapi/formula": "^1.2.0",
+            "@hapi/hoek": "^8.2.4",
+            "@hapi/pinpoint": "^1.0.2",
+            "@hapi/topo": "^3.1.3"
+          }
+        }
       }
     },
     "@hapi/hoek": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
-      "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A=="
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.0.tgz",
+      "integrity": "sha512-C0QL9bmgUXTSuf8nDeGrpMjtJG7tPUr8wG6/wxPbP62tGwCwQtdMSJYfESowmY4P3Hn593f+8OzNY5bckcu/LQ=="
     },
     "@hapi/inert": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@hapi/inert/-/inert-5.2.1.tgz",
-      "integrity": "sha512-kovx94LVcT9jELc+k4xuR+1lsdmimjHKn9SpI/YAXDioO7m4YzksEBSmneH3ZwVWVnl2j66Sfzvs2IweHRxyNA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@hapi/inert/-/inert-5.2.2.tgz",
+      "integrity": "sha512-8IaGfAEF8SwZtpdaTq0G3aDPG35ZTfWKjnMNniG2N3kE+qioMsBuImIGxna8TNQ+sYMXYK78aqmvzbQHno8qSQ==",
       "requires": {
         "@hapi/ammo": "3.x.x",
         "@hapi/boom": "7.x.x",
         "@hapi/bounce": "1.x.x",
         "@hapi/hoek": "8.x.x",
-        "@hapi/joi": "15.x.x",
+        "@hapi/joi": "16.x.x",
         "lru-cache": "4.1.x"
       },
       "dependencies": {
-        "@hapi/hoek": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.1.0.tgz",
-          "integrity": "sha512-b1J4jxYnW+n6lC91V6Pqg9imP9BZq0HNCeM+3sbXg05rQsE9cGYrKFpZjyztVesGmNRE6R+QaEoWGATeIiUVjA=="
+        "@hapi/joi": {
+          "version": "16.1.7",
+          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.7.tgz",
+          "integrity": "sha512-anaIgnZhNooG3LJLrTFzgGALTiO97zRA1UkvQHm9KxxoSiIzCozB3RCNCpDnfhTJD72QlrHA8nwGmNgpFFCIeg==",
+          "requires": {
+            "@hapi/address": "^2.1.2",
+            "@hapi/formula": "^1.2.0",
+            "@hapi/hoek": "^8.2.4",
+            "@hapi/pinpoint": "^1.0.2",
+            "@hapi/topo": "^3.1.3"
+          }
         },
         "lru-cache": {
           "version": "4.1.5",
@@ -208,107 +241,150 @@
       }
     },
     "@hapi/iron": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-5.1.0.tgz",
-      "integrity": "sha512-+MK3tBPkEKd50SrDTRXa2DVvE0UTPFKxGbodlbQpNP9SVlxi+ZwA640VJtMNj84FZh81UUxda8AOLPRKFffnEA==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-5.1.4.tgz",
+      "integrity": "sha512-+ElC+OCiwWLjlJBmm8ZEWjlfzTMQTdgPnU/TsoU5QsktspIWmWi9IU4kU83nH+X/SSya8TP8h8P11Wr5L7dkQQ==",
       "requires": {
         "@hapi/b64": "4.x.x",
         "@hapi/boom": "7.x.x",
+        "@hapi/bourne": "1.x.x",
         "@hapi/cryptiles": "4.x.x",
-        "@hapi/hoek": "6.x.x"
+        "@hapi/hoek": "8.x.x"
       }
     },
     "@hapi/joi": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.0.tgz",
-      "integrity": "sha512-n6kaRQO8S+kepUTbXL9O/UOL788Odqs38/VOfoCrATDtTvyfiO3fgjlSRaNkHabpTLgM7qru9ifqXlXbXk8SeQ==",
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
+      "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
       "requires": {
         "@hapi/address": "2.x.x",
-        "@hapi/hoek": "6.x.x",
-        "@hapi/marker": "1.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/hoek": "8.x.x",
         "@hapi/topo": "3.x.x"
       }
     },
-    "@hapi/marker": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/marker/-/marker-1.0.0.tgz",
-      "integrity": "sha512-JOfdekTXnJexfE8PyhZFyHvHjt81rBFSAbTIRAhF2vv/2Y1JzoKsGqxH/GpZJoF7aEfYok8JVcAHmSz1gkBieA=="
-    },
     "@hapi/mimos": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-4.1.0.tgz",
-      "integrity": "sha512-CkxOB15TFZDMl5tQ5qezKZvvBnkRYVc8YksNfA5TnqQMMsU7vGPyvuuNFqj+15bfEwHyM6qasxyQNdkX9B/cQw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-4.1.1.tgz",
+      "integrity": "sha512-CXoi/zfcTWfKYX756eEea8rXJRIb9sR4d7VwyAH9d3BkDyNgAesZxvqIdm55npQc6S9mU3FExinMAQVlIkz0eA==",
       "requires": {
-        "@hapi/hoek": "6.x.x",
+        "@hapi/hoek": "8.x.x",
         "mime-db": "1.x.x"
       }
     },
     "@hapi/nigel": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-3.1.0.tgz",
-      "integrity": "sha512-IJyau32pz5Bf7pzUU/8AIn/SvPvhLMQcOel6kM7ECpKyPc895AwttSusRKfgTwfxZOEG6W8DnNv25gLtqrVFSg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-3.1.1.tgz",
+      "integrity": "sha512-R9YWx4S8yu0gcCBrMUDCiEFm1SQT895dMlYoeNBp8I6YhF1BFF1iYPueKA2Kkp9BvyHdjmvrxCOns7GMmpl+Fw==",
       "requires": {
-        "@hapi/hoek": "6.x.x",
+        "@hapi/hoek": "8.x.x",
         "@hapi/vise": "3.x.x"
       }
     },
     "@hapi/pez": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-4.1.0.tgz",
-      "integrity": "sha512-c+AxL8/cCj+7FB+tzJ5FhWKYP8zF7/7mA3Ft3a5y7h6YT26qzhj5d2JY27jur30KaZbrZAd4ofXXkqvE/IpJlA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-4.1.1.tgz",
+      "integrity": "sha512-TUa2C7Xk6J69HWrm+Ad+O6dFvdVAG0BiFUYaRsmkdWjFIfwHBCaOI1dWT/juNukSb39Lj6/mDVyjN+H4nKB3xg==",
       "requires": {
         "@hapi/b64": "4.x.x",
         "@hapi/boom": "7.x.x",
         "@hapi/content": "4.x.x",
-        "@hapi/hoek": "6.x.x",
+        "@hapi/hoek": "8.x.x",
         "@hapi/nigel": "3.x.x"
       }
     },
+    "@hapi/pinpoint": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-1.0.2.tgz",
+      "integrity": "sha512-dtXC/WkZBfC5vxscazuiJ6iq4j9oNx1SHknmIr8hofarpKUZKmlUVYVIhNVzIEgK5Wrc4GMHL5lZtt1uS2flmQ=="
+    },
     "@hapi/podium": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-3.4.0.tgz",
-      "integrity": "sha512-IwyewAPGlCoq+g5536PKSDqSTfgpwbj+q4cBJpEUNqzwc5C5SM2stuFsULU7x1jKeWevfgWDoYWC75ML4IOYug==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-3.4.2.tgz",
+      "integrity": "sha512-g9zlAkRL2uDlnEo64xzEhFLblf4fdL5Z6evAO0wJhdxEvokI/+6ryv7k6uhND481LiLzQz8qTtPYMuhH1hichw==",
       "requires": {
-        "@hapi/hoek": "6.x.x",
-        "@hapi/joi": "15.x.x"
+        "@hapi/hoek": "8.x.x",
+        "@hapi/joi": "16.x.x"
+      },
+      "dependencies": {
+        "@hapi/joi": {
+          "version": "16.1.7",
+          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.7.tgz",
+          "integrity": "sha512-anaIgnZhNooG3LJLrTFzgGALTiO97zRA1UkvQHm9KxxoSiIzCozB3RCNCpDnfhTJD72QlrHA8nwGmNgpFFCIeg==",
+          "requires": {
+            "@hapi/address": "^2.1.2",
+            "@hapi/formula": "^1.2.0",
+            "@hapi/hoek": "^8.2.4",
+            "@hapi/pinpoint": "^1.0.2",
+            "@hapi/topo": "^3.1.3"
+          }
+        }
       }
     },
     "@hapi/shot": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-4.1.0.tgz",
-      "integrity": "sha512-rpUU5cF08fqAZLLnue6Sy0osj1QMPbrYskehxtLFPdk7CwlPcu9N/wRtgu7vDHTQCKTkag6M8sjc8V8p8lSxpg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-4.1.2.tgz",
+      "integrity": "sha512-6LeHLjvsq/bQ0R+fhEyr7mqExRGguNTrxFZf5DyKe3CK6pNabiGgYO4JVFaRrLZ3JyuhkS0fo8iiRE2Ql2oA/A==",
       "requires": {
-        "@hapi/hoek": "6.x.x",
-        "@hapi/joi": "15.x.x"
+        "@hapi/hoek": "8.x.x",
+        "@hapi/joi": "16.x.x"
+      },
+      "dependencies": {
+        "@hapi/joi": {
+          "version": "16.1.7",
+          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.7.tgz",
+          "integrity": "sha512-anaIgnZhNooG3LJLrTFzgGALTiO97zRA1UkvQHm9KxxoSiIzCozB3RCNCpDnfhTJD72QlrHA8nwGmNgpFFCIeg==",
+          "requires": {
+            "@hapi/address": "^2.1.2",
+            "@hapi/formula": "^1.2.0",
+            "@hapi/hoek": "^8.2.4",
+            "@hapi/pinpoint": "^1.0.2",
+            "@hapi/topo": "^3.1.3"
+          }
+        }
       }
     },
     "@hapi/somever": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-2.1.0.tgz",
-      "integrity": "sha512-kMPewbpgLd0MSlNg0bjvq57Levozbg7c3O0idpWRxRgXfXBALNATLf8GRVbnMehYXAh7YRD2mR/91kginDtJ2Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-2.1.1.tgz",
+      "integrity": "sha512-cic5Sto4KGd9B0oQSdKTokju+rYhCbdpzbMb0EBnrH5Oc1z048hY8PaZ1lx2vBD7I/XIfTQVQetBH57fU51XRA==",
       "requires": {
         "@hapi/bounce": "1.x.x",
-        "@hapi/hoek": "6.x.x"
+        "@hapi/hoek": "8.x.x"
       }
     },
     "@hapi/statehood": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-6.1.0.tgz",
-      "integrity": "sha512-qc8Qq3kg0b3XK7siXf6DK0wp+rcOrXv336kIP6YrtD9TbQ45TsBobwKkUXB+4R3GCCQ8a6tOj8FR/9bdtjKJCA==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-6.1.2.tgz",
+      "integrity": "sha512-pYXw1x6npz/UfmtcpUhuMvdK5kuOGTKcJNfLqdNptzietK2UZH5RzNJSlv5bDHeSmordFM3kGItcuQWX2lj2nQ==",
       "requires": {
         "@hapi/boom": "7.x.x",
         "@hapi/bounce": "1.x.x",
         "@hapi/bourne": "1.x.x",
         "@hapi/cryptiles": "4.x.x",
-        "@hapi/hoek": "6.x.x",
+        "@hapi/hoek": "8.x.x",
         "@hapi/iron": "5.x.x",
-        "@hapi/joi": "15.x.x"
+        "@hapi/joi": "16.x.x"
+      },
+      "dependencies": {
+        "@hapi/joi": {
+          "version": "16.1.7",
+          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.7.tgz",
+          "integrity": "sha512-anaIgnZhNooG3LJLrTFzgGALTiO97zRA1UkvQHm9KxxoSiIzCozB3RCNCpDnfhTJD72QlrHA8nwGmNgpFFCIeg==",
+          "requires": {
+            "@hapi/address": "^2.1.2",
+            "@hapi/formula": "^1.2.0",
+            "@hapi/hoek": "^8.2.4",
+            "@hapi/pinpoint": "^1.0.2",
+            "@hapi/topo": "^3.1.3"
+          }
+        }
       }
     },
     "@hapi/subtext": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-6.1.1.tgz",
-      "integrity": "sha512-Y7NjKFRPwlzKRw5IdwRou42hR4IBQZolT+/DlvfSr/CBjGyu38n5+9LKfNKzqB/0AVEk+xynCijsx1o1UVWX8A==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-6.1.2.tgz",
+      "integrity": "sha512-G1kqD1E2QdxpvpL26WieIyo3z0qCa/sAGSa2TJI/PYPWCR9rL0rqFvhWY774xPZ4uK1PV3TIaJcx8AruAvxclg==",
       "requires": {
         "@hapi/boom": "7.x.x",
         "@hapi/bourne": "1.x.x",
@@ -317,13 +393,6 @@
         "@hapi/hoek": "8.x.x",
         "@hapi/pez": "4.x.x",
         "@hapi/wreck": "15.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.1.0.tgz",
-          "integrity": "sha512-b1J4jxYnW+n6lC91V6Pqg9imP9BZq0HNCeM+3sbXg05rQsE9cGYrKFpZjyztVesGmNRE6R+QaEoWGATeIiUVjA=="
-        }
       }
     },
     "@hapi/teamwork": {
@@ -332,36 +401,29 @@
       "integrity": "sha512-61tiqWCYvMKP7fCTXy0M4VE6uNIwA0qvgFoiDubgfj7uqJ0fdHJFQNnVPGrxhLWlwz0uBPWrQlBH7r8y9vFITQ=="
     },
     "@hapi/topo": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.2.tgz",
-      "integrity": "sha512-r+aumOqJ5QbD6aLPJWqVjMAPsx5pZKz+F5yPqXZ/WWG9JTtHbQqlzrJoknJ0iJxLj9vlXtmpSdjlkszseeG8OA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.4.tgz",
+      "integrity": "sha512-aVWQTOI9wBD6zawmOr6f+tdEIxQC8JXfQVLTjgGe8YEStAWGn/GNNVTobKJhbWKveQj2RyYF3oYbO9SC8/eOCA==",
       "requires": {
         "@hapi/hoek": "8.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.1.0.tgz",
-          "integrity": "sha512-b1J4jxYnW+n6lC91V6Pqg9imP9BZq0HNCeM+3sbXg05rQsE9cGYrKFpZjyztVesGmNRE6R+QaEoWGATeIiUVjA=="
-        }
       }
     },
     "@hapi/vise": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-3.1.0.tgz",
-      "integrity": "sha512-DUDzV0D4iVO5atghsjGZtzaF0HVtRLcxcnH6rAONyH0stnoLiFloGEuP5nkbIPU0B9cgWTzTUsQPuNHBzxy9Yw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-3.1.1.tgz",
+      "integrity": "sha512-OXarbiCSadvtg+bSdVPqu31Z1JoBL+FwNYz3cYoBKQ5xq1/Cr4A3IkGpAZbAuxU5y4NL5pZFZG3d2a3ZGm/dOQ==",
       "requires": {
-        "@hapi/hoek": "6.x.x"
+        "@hapi/hoek": "8.x.x"
       }
     },
     "@hapi/wreck": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-15.0.1.tgz",
-      "integrity": "sha512-ByXQna/W1FZk7dg8NEhL79u4QkhzszRz76VpgyGstSH8bLM01a0C8RsxmUBgi6Tjkag5jA9kaEIhF9dLpMrtBw==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-15.1.0.tgz",
+      "integrity": "sha512-tQczYRTTeYBmvhsek/D49En/5khcShaBEmzrAaDjMrFXKJRuF8xA8+tlq1ETLBFwGd6Do6g2OC74rt11kzawzg==",
       "requires": {
         "@hapi/boom": "7.x.x",
         "@hapi/bourne": "1.x.x",
-        "@hapi/hoek": "6.x.x"
+        "@hapi/hoek": "8.x.x"
       }
     },
     "@protobufjs/utf8": {
@@ -373,6 +435,38 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
+    },
+    "@sinonjs/commons": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.6.0.tgz",
+      "integrity": "sha512-w4/WHG7C4WWFyE5geCieFJF6MZkbW4VAriol5KlmQXpAQdxvV0p26sqNZOW6Qyw6Y0l9K4g+cHvvczR2sEEpqg==",
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
+      "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+      "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
+      "requires": {
+        "@sinonjs/commons": "^1.3.0",
+        "array-from": "^2.1.1",
+        "lodash": "^4.17.15"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ=="
     },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
@@ -396,11 +490,12 @@
       }
     },
     "abstract-leveldown": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.0.3.tgz",
-      "integrity": "sha512-jzewKKpZbaYUa6HTThnrl+GrJhzjEAeuc7hTVpZdzg7kupXZFoqQDFwyOwLNbmJKJlmzw8yiipMPkDiuKkT06Q==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.1.tgz",
+      "integrity": "sha512-zUgomHedGBCThDkUtc1bfilu2jEhRZ7Dk3RePhtMma/akw7UK2Upm2R5Dd8ynRBEt3uscwbWO0VQNx22/7RtWg==",
       "requires": {
         "level-concat-iterator": "~2.0.0",
+        "level-supports": "~1.0.0",
         "xtend": "~4.0.0"
       }
     },
@@ -419,15 +514,15 @@
       }
     },
     "acorn": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
-      "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
       "dev": true
     },
     "acorn-jsx": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
-      "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.2.tgz",
+      "integrity": "sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==",
       "dev": true
     },
     "after": {
@@ -513,6 +608,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU="
     },
     "array-includes": {
       "version": "3.0.3",
@@ -631,6 +731,11 @@
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
     "backo2": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
@@ -642,9 +747,9 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base-x": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.6.tgz",
-      "integrity": "sha512-4PaF8u2+AlViJxRVjurkLTxpp7CaFRD/jo5rPT9ONnKxyhQ8f59yzamEvq7EkriG56yn5On4ONyaG75HLqr46w==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.7.tgz",
+      "integrity": "sha512-zAKJGuQPihXW22fkrfOclUUZXM2g92z5GzlSMHxhO6r6Qj+Nm0ccaGNBzDZojzwOMkpjAv4J0fOv1U4go+a4iw==",
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -670,9 +775,9 @@
       "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
     "base64id": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
-      "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog=="
     },
     "bech32": {
       "version": "1.1.3",
@@ -716,9 +821,9 @@
       "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
     },
     "bip174": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/bip174/-/bip174-1.0.0.tgz",
-      "integrity": "sha512-AaoWrkYtv6A2y8H+qzs6NvRWypzNbADT8PQGpM9rnP+jLzeol+uzhe3Myeuq/dwrHYtmsW8V71HmX2oXhQGagw=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bip174/-/bip174-1.0.1.tgz",
+      "integrity": "sha512-Mq2aFs1TdMfxBpYPg7uzjhsiXbAtoVq44TNjEWtvuZBiBgc3m7+n55orYMtTAxdg7jWbL4DtH0MKocJER4xERQ=="
     },
     "bip32": {
       "version": "2.0.4",
@@ -748,13 +853,13 @@
       "integrity": "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow=="
     },
     "bitcoinjs-lib": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-5.1.2.tgz",
-      "integrity": "sha512-Qa1TY8xaFRaLPD2YunfQX1vhHAh0387SJ/Zu7lNSRyzpg8lDru8gv+w6pqxOkcdj4dm4Fn1JmWb0m8Oy+8TfiA==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-5.1.6.tgz",
+      "integrity": "sha512-NgvnA8XXUuzpuBnVs1plzZvVOYsuont4KPzaGcVIwjktYQbCk1hUkXnt4wujIOBscNsXuu+plVbPYvtMosZI/w==",
       "requires": {
         "@types/node": "10.12.18",
         "bech32": "^1.1.2",
-        "bip174": "^1.0.0",
+        "bip174": "^1.0.1",
         "bip32": "^2.0.4",
         "bip66": "^1.1.0",
         "bitcoin-ops": "^1.4.0",
@@ -866,9 +971,9 @@
       }
     },
     "buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
-      "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+      "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4"
@@ -880,9 +985,9 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "buffer-indexof": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-0.0.2.tgz",
-      "integrity": "sha1-7Q82t64WamanzRdMBGeuje3wCPU="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
+      "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g=="
     },
     "buffer-peek-stream": {
       "version": "1.0.1",
@@ -900,6 +1005,13 @@
       "integrity": "sha1-RCfb/1NzG2HXpxq6R/UDOWYTeEo=",
       "requires": {
         "buffer-indexof": "~0.0.0"
+      },
+      "dependencies": {
+        "buffer-indexof": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-0.0.2.tgz",
+          "integrity": "sha1-7Q82t64WamanzRdMBGeuje3wCPU="
+        }
       }
     },
     "buffer-xor": {
@@ -1020,6 +1132,25 @@
         "multibase": "~0.6.0",
         "multihashes": "~0.4.14",
         "yargs": "^13.2.2"
+      },
+      "dependencies": {
+        "yargs": {
+          "version": "13.3.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+          "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.1"
+          }
+        }
       }
     },
     "cids": {
@@ -1053,11 +1184,11 @@
       "integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w=="
     },
     "cli-cursor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
       "requires": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "^3.1.0"
       }
     },
     "cli-spinners": {
@@ -1118,10 +1249,18 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.1.tgz",
+      "integrity": "sha512-cCuLsMhJeWQ/ZpsFTbE765kvVfoeSddc4nU3up4fV+fDBcfUXnbITJ+JzhkdjzOqhURjZgujxaioam4RM9yGUg=="
     },
     "component-bind": {
       "version": "1.0.0",
@@ -1261,9 +1400,9 @@
       }
     },
     "datastore-fs": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/datastore-fs/-/datastore-fs-0.8.0.tgz",
-      "integrity": "sha512-uaNVJtMQKNxxJkqKGrI5dYhciUIZSntHVCS3pU4qimke8tSp9pCkXwgLoxORxX1z411sF1Im5cc9RlnJT7NOMg==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/datastore-fs/-/datastore-fs-0.8.1.tgz",
+      "integrity": "sha512-kSWQwTWa7Pf6HIBvJVQ0b8BvKqW6y22zWJ1Vp0h34R5loq48hOYQ++4ckZFWyzOvF3bJAi5X2euF01RPKqMJIQ==",
       "requires": {
         "async": "^2.6.1",
         "datastore-core": "~0.6.0",
@@ -1381,11 +1520,11 @@
       "integrity": "sha512-k09hcQcTDY+cwgiwa6PYKLm3jlagNzQ+RSvhjzESOGOx+MNOuXkxTfEvPrO1IOQ81tArCFYQgi631clB70RpQw=="
     },
     "deferred-leveldown": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.1.0.tgz",
-      "integrity": "sha512-PvDY+BT2ONu2XVRgxHb77hYelLtMYxKSGuWuJJdVRXh9ntqx9GYTFJno/SKAz5xcd+yjQwyQeIZrUPjPvA52mg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.3.0.tgz",
+      "integrity": "sha512-a59VOT+oDy7vtAbLRCZwWgxu2BaCfd5Hk7wxJd48ei7I+nsg8Orlb9CLG0PMZienk9BSUKgeAqkO2+Lw+1+Ukw==",
       "requires": {
-        "abstract-leveldown": "~6.0.0",
+        "abstract-leveldown": "~6.2.1",
         "inherits": "^2.0.3"
       }
     },
@@ -1393,7 +1532,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       },
@@ -1401,15 +1539,14 @@
         "object-keys": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-          "dev": true
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
         }
       }
     },
     "deglob": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/deglob/-/deglob-3.1.0.tgz",
-      "integrity": "sha512-al10l5QAYaM/PeuXkAr1Y9AQz0LCtWsnJG23pIgh44hDxHFOj36l6qvhfjnIWBYwZOqM1fXUFV9tkjL7JPdGvw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/deglob/-/deglob-4.0.1.tgz",
+      "integrity": "sha512-/g+RDZ7yf2HvoW+E5Cy+K94YhgcFgr6C8LuHZD1O5HoNPkf3KY6RfXJ0DBGlB/NkLi5gml+G9zqRzk9S0mHZCg==",
       "dev": true,
       "requires": {
         "find-root": "^1.0.0",
@@ -1421,12 +1558,22 @@
       },
       "dependencies": {
         "ignore": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.2.tgz",
-          "integrity": "sha512-vdqWBp7MyzdmHkkRWV5nY+PfGRbYbahfuvsBCh277tq+w9zyNi7h5CYJCK0kmzti9kU+O/cB7sE8HvKv6aXAKQ==",
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+          "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
           "dev": true
         }
       }
+    },
+    "delay": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-4.3.0.tgz",
+      "integrity": "sha512-Lwaf3zVFDMBop1yDuFZ19F9WyGcZcGacsbdlZtWjQmM50tOcMntm1njF/Nb/Vjij3KaSvCF+sEYGKrrjObu2NA=="
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "delimit-stream": {
       "version": "0.1.0",
@@ -1438,13 +1585,10 @@
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
       "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
     },
-    "dicer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
-      "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
-      "requires": {
-        "streamsearch": "0.1.2"
-      }
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
     },
     "dlv": {
       "version": "1.1.3",
@@ -1493,9 +1637,9 @@
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "elliptic": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
-      "integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.1.tgz",
+      "integrity": "sha512-xvJINNLbTeWQjrl6X+7eQCrIy/YPv5XCpKW6kB5mKvtnGILoLDcySuwomfdzt0BMdLNVnuRNTuzKNHj0bva1Cg==",
       "requires": {
         "bn.js": "^4.4.0",
         "brorand": "^1.0.1",
@@ -1512,69 +1656,56 @@
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
     },
     "encoding-down": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-6.1.0.tgz",
-      "integrity": "sha512-pBW1mbuQDHQhQLBtqarX8x2oLynahiOzBY5L/BosNqcstJ8MjpSc3rx1yCUIqb6bUE2vsp3t0BaXS0ZDP1s5pg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-6.2.0.tgz",
+      "integrity": "sha512-XlIoQMBMbU4aE01uSKpAix0sXBJWK8YPhuOdvKa1CroThZyUpj0zWzt+bbe7g1KWsdhNFFzHkQHSdDymVtpJ1w==",
       "requires": {
-        "abstract-leveldown": "^6.0.0",
+        "abstract-leveldown": "^6.1.1",
         "inherits": "^2.0.3",
         "level-codec": "^9.0.0",
         "level-errors": "^2.0.0"
       }
     },
     "end-of-stream": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "requires": {
         "once": "^1.4.0"
       }
     },
     "engine.io": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.3.2.tgz",
-      "integrity": "sha512-AsaA9KG7cWPXWHp5FvHdDWY3AMWeZ8x+2pUVLcn71qE5AtAzgGbxuclOytygskw8XGmiQafTmnI9Bix3uihu2w==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.4.0.tgz",
+      "integrity": "sha512-XCyYVWzcHnK5cMz7G4VTu2W7zJS7SM1QkcelghyIk/FmobWBtXE7fwhBusEKvCSqc3bMh8fNFMlUkCKTFRxH2w==",
       "requires": {
         "accepts": "~1.3.4",
-        "base64id": "1.0.0",
+        "base64id": "2.0.0",
         "cookie": "0.3.1",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.1.0",
-        "ws": "~6.1.0"
+        "debug": "~4.1.0",
+        "engine.io-parser": "~2.2.0",
+        "ws": "^7.1.2"
       },
       "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
         "ws": {
-          "version": "6.1.4",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
-          "integrity": "sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==",
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.1.2.tgz",
+          "integrity": "sha512-gftXq3XI81cJCgkUiAVixA0raD9IVmXqsylCrjRygw4+UOOGzPoxnQ6r/CnVL9i+mDncJo94tSkyrtuuQVBmrg==",
           "requires": {
-            "async-limiter": "~1.0.0"
+            "async-limiter": "^1.0.0"
           }
         }
       }
     },
     "engine.io-client": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.3.2.tgz",
-      "integrity": "sha512-y0CPINnhMvPuwtqXfsGuWE8BB66+B6wTtCofQDRecMQPYX3MYUZXFNKDhdrSe3EVjgOu4V3rxdeqN/Tr91IgbQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.0.tgz",
+      "integrity": "sha512-a4J5QO2k99CM2a0b12IznnyQndoEvtA4UAldhGzKqnHf42I3Qs2W5SPnDvatZRcMaNZs4IevVicBPayxYt6FwA==",
       "requires": {
         "component-emitter": "1.2.1",
         "component-inherit": "0.0.3",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.1.1",
+        "debug": "~4.1.0",
+        "engine.io-parser": "~2.2.0",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "parseqs": "0.0.5",
@@ -1584,19 +1715,6 @@
         "yeast": "0.1.2"
       },
       "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
         "ws": {
           "version": "6.1.4",
           "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
@@ -1608,9 +1726,9 @@
       }
     },
     "engine.io-parser": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.3.tgz",
-      "integrity": "sha512-6HXPre2O4Houl7c4g7Ic/XzPnHBvaEmN90vtRO9uLmwtRqQmTOw0QMevL1TOfL2Cpu1VzsaTmMotQgMdkzGkVA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.0.tgz",
+      "integrity": "sha512-6I3qD9iUxotsC5HEMuuGsKA0cXerGz+4uGcXQEkfBidgKf0amsjrrtwcbwK/nzpZBxclXlV7gGl9dgWvu4LF6w==",
       "requires": {
         "after": "0.8.2",
         "arraybuffer.slice": "~0.0.7",
@@ -1662,7 +1780,6 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
       "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
-      "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.0",
         "function-bind": "^1.1.1",
@@ -1675,8 +1792,7 @@
         "object-keys": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-          "dev": true
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
         }
       }
     },
@@ -1684,7 +1800,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
       "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -1697,9 +1812,9 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.1.0.tgz",
-      "integrity": "sha512-QhrbdRD7ofuV09IuE2ySWBz0FyXCq0rriLTZXZqaWSI79CVtHVRdkFuFTViiqzZhkCgfOh9USpriuGN2gIpZDQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.4.0.tgz",
+      "integrity": "sha512-WTVEzK3lSFoXUovDHEbkJqCVPEPwbhCq4trDktNI6ygs7aO41d4cDT0JFAT5MivzZeVLWlg7vHL+bgrQv/t3vA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -1709,9 +1824,9 @@
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
         "eslint-scope": "^5.0.0",
-        "eslint-utils": "^1.3.1",
-        "eslint-visitor-keys": "^1.0.0",
-        "espree": "^6.0.0",
+        "eslint-utils": "^1.4.2",
+        "eslint-visitor-keys": "^1.1.0",
+        "espree": "^6.1.1",
         "esquery": "^1.0.1",
         "esutils": "^2.0.2",
         "file-entry-cache": "^5.0.1",
@@ -1755,9 +1870,9 @@
           },
           "dependencies": {
             "semver": {
-              "version": "5.7.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-              "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
               "dev": true
             }
           }
@@ -1771,15 +1886,15 @@
       }
     },
     "eslint-config-standard": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-13.0.1.tgz",
-      "integrity": "sha512-zLKp4QOgq6JFgRm1dDCVv1Iu0P5uZ4v5Wa4DTOkg2RFMxdCX/9Qf7lz9ezRj2dBRa955cWQF/O/LWEiYWAHbTw==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.0.tgz",
+      "integrity": "sha512-EF6XkrrGVbvv8hL/kYa/m6vnvmUT+K82pJJc4JJVMM6+Qgqh0pnwprSxdduDLB9p/7bIxD+YV5O0wfb8lmcPbA==",
       "dev": true
     },
     "eslint-config-standard-jsx": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-7.0.0.tgz",
-      "integrity": "sha512-OiKOF3MFVmWOCVfsi8GHlVorOEiBsPzAnUhM3c6HML94O2krbdQ/eMABySHgHHOIBYRls9sR9I3lo6O0vXhVEg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-8.1.0.tgz",
+      "integrity": "sha512-ULVC8qH8qCqbU792ZOO6DaiaZyHNS/5CZt3hKqHkEhVlhPEPN3nfBqqxJCyp59XrjIBZPu1chMYe9T2DXZ7TMw==",
       "dev": true
     },
     "eslint-import-resolver-node": {
@@ -1837,13 +1952,21 @@
       }
     },
     "eslint-plugin-es": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-1.4.0.tgz",
-      "integrity": "sha512-XfFmgFdIUDgvaRAlaXUkxrRg5JSADoRC8IkKLc/cISeR3yHVMefFHQZpcyXXEUUPHfy5DwviBcrfqlyqEwlQVw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-2.0.0.tgz",
+      "integrity": "sha512-f6fceVtg27BR02EYnBhgWLFQfK6bN4Ll0nQFrBHOlCsAyxeZkn0NHns5O0YZOPrV1B3ramd6cgFwaoFLcSkwEQ==",
       "dev": true,
       "requires": {
-        "eslint-utils": "^1.3.0",
-        "regexpp": "^2.0.1"
+        "eslint-utils": "^1.4.2",
+        "regexpp": "^3.0.0"
+      },
+      "dependencies": {
+        "regexpp": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
+          "integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g==",
+          "dev": true
+        }
       }
     },
     "eslint-plugin-import": {
@@ -1993,13 +2116,13 @@
       }
     },
     "eslint-plugin-node": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-9.1.0.tgz",
-      "integrity": "sha512-ZwQYGm6EoV2cfLpE1wxJWsfnKUIXfM/KM09/TlorkukgCAwmkgajEJnPCmyzoFPQQkmvo5DrW/nyKutNIw36Mw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-10.0.0.tgz",
+      "integrity": "sha512-1CSyM/QCjs6PXaT18+zuAXsjXGIGo5Rw630rSKwokSs2jrYURQc4R5JZpoanNCqwNmepg+0eZ9L7YiRUJb8jiQ==",
       "dev": true,
       "requires": {
-        "eslint-plugin-es": "^1.4.0",
-        "eslint-utils": "^1.3.1",
+        "eslint-plugin-es": "^2.0.0",
+        "eslint-utils": "^1.4.2",
         "ignore": "^5.1.1",
         "minimatch": "^3.0.4",
         "resolve": "^1.10.1",
@@ -2007,9 +2130,9 @@
       },
       "dependencies": {
         "ignore": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.2.tgz",
-          "integrity": "sha512-vdqWBp7MyzdmHkkRWV5nY+PfGRbYbahfuvsBCh277tq+w9zyNi7h5CYJCK0kmzti9kU+O/cB7sE8HvKv6aXAKQ==",
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+          "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
           "dev": true
         }
       }
@@ -2049,9 +2172,9 @@
       }
     },
     "eslint-plugin-standard": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.0.tgz",
-      "integrity": "sha512-OwxJkR6TQiYMmt1EsNRMe5qG3GsbjlcOhbGUBY4LtavF9DsLaTcoR+j2Tdjqi23oUwKNUqX7qcn5fPStafMdlA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.1.tgz",
+      "integrity": "sha512-v/KBnfyaOMPmZc/dmc6ozOdWqekGp7bBGq4jLAecEfPGmfKiWS4sA8sC0LqiV9w5qmXAtXVn4M3p1jSyhY85SQ==",
       "dev": true
     },
     "eslint-scope": {
@@ -2065,29 +2188,29 @@
       }
     },
     "eslint-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.0.tgz",
-      "integrity": "sha512-7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.0.0"
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
       "dev": true
     },
     "espree": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-6.0.0.tgz",
-      "integrity": "sha512-lJvCS6YbCn3ImT3yKkPe0+tJ+mH6ljhGNjHQH9mRtiO6gjhVAOhVXW1yjnwqGwTkK3bGbye+hb00nFNmu0l/1Q==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
+      "integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
       "dev": true,
       "requires": {
-        "acorn": "^6.0.7",
-        "acorn-jsx": "^5.0.0",
-        "eslint-visitor-keys": "^1.0.0"
+        "acorn": "^7.0.0",
+        "acorn-jsx": "^5.0.2",
+        "eslint-visitor-keys": "^1.1.0"
       }
     },
     "esprima": {
@@ -2115,9 +2238,9 @@
       }
     },
     "estraverse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
     },
     "esutils": {
@@ -2276,6 +2399,11 @@
             }
           }
         },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
         "semver": {
           "version": "5.4.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
@@ -2289,9 +2417,9 @@
       }
     },
     "ethereumjs-common": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.3.0.tgz",
-      "integrity": "sha512-/jdFHyHOIS3FiAnunwRZ+oNulFtNNSHyWii3PaNHReOUmBAxij7KMyZLKh0tE16JEsJtXOVz1ceYuq++ILzv+g=="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.3.2.tgz",
+      "integrity": "sha512-GkltYRIqBLzaZLmF/K3E+g9lZ4O4FL+TtpisAlD3N+UVlR+mrtoG+TvxavqVa6PwOY4nKIEMe5pl6MrTio3Lww=="
     },
     "ethereumjs-tx": {
       "version": "1.3.7",
@@ -2331,9 +2459,9 @@
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+      "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
     },
     "evp_bytestokey": {
       "version": "1.0.3",
@@ -2387,10 +2515,10 @@
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
       "dev": true
     },
-    "fast-json-parse": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/fast-json-parse/-/fast-json-parse-1.0.3.tgz",
-      "integrity": "sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw=="
+    "fast-fifo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.0.0.tgz",
+      "integrity": "sha512-4VEXmjxLj7sbs8J//cn2qhRap50dGzF5n8fjay8mau+Jn4hxSeR3xPFwxMaQq/pDaq7+KQk0PAbC2+nWDkJrmQ=="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -2405,14 +2533,14 @@
       "dev": true
     },
     "fast-redact": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-1.5.0.tgz",
-      "integrity": "sha512-Afo61CgUjkzdvOKDHn08qnZ0kwck38AOGcMlvSGzvJbIab6soAP5rdoQayecGCDsD69AiF9vJBXyq31eoEO2tQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-2.0.0.tgz",
+      "integrity": "sha512-zxpkULI9W9MNTK2sJ3BpPQrTEXFNESd2X6O1tXMFpK/XM0G5c5Rll2EVYZH2TqI3xRGK/VaJ+eEOt7pnENJpeA=="
     },
     "fast-safe-stringify": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
-      "integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg=="
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
     },
     "fast-write-atomic": {
       "version": "0.2.1",
@@ -2438,9 +2566,9 @@
       }
     },
     "file-type": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-12.1.0.tgz",
-      "integrity": "sha512-aZkf42yWGiH+vSOpbVgvbnoRuX4JiitMX9pHYqTHemNQ3lrx64iHi33YGAP7TSJSno56kxQY1lHmw8S6ujlFUg=="
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-12.3.0.tgz",
+      "integrity": "sha512-4E4Esq9KLwjYCY32E7qSmd0h7LefcniZHX+XcdJ4Wfx1uGJX7QCigiqw/U0yT7WOslm28yhxl87DJ0wHYv0RAA=="
     },
     "file-uri-to-path": {
       "version": "1.0.0",
@@ -2498,6 +2626,14 @@
       "resolved": "https://registry.npmjs.org/fnv1a/-/fnv1a-1.0.1.tgz",
       "integrity": "sha1-kV4tbQI8Q9UiStn20qPEFW9XEvU="
     },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "requires": {
+        "is-callable": "^1.1.3"
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -2511,10 +2647,30 @@
         "for-in": "^1.0.1"
       }
     },
+    "form-data": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
     "fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
+    "fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -2540,8 +2696,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -3083,9 +3238,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
-      "integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
@@ -3104,6 +3259,16 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
+    },
+    "globalthis": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.0.tgz",
+      "integrity": "sha512-vcCAZTJ3r5Qcu5l8/2oyVdoFwxKgfYnMTR2vwWeux/NAVZK3PwcMaWkdUIn4GJbmKuRK7xcvDsLuK+CKcXyodg==",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "object-keys": "^1.0.12"
+      }
     },
     "got": {
       "version": "9.6.0",
@@ -3147,21 +3312,20 @@
       }
     },
     "hapi-pino": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/hapi-pino/-/hapi-pino-6.0.2.tgz",
-      "integrity": "sha512-n2atjPT0waN8vmGqQSn68Au8lyJmaalLK3ucu+QWOZaBDm4l3N9lo8u8kaaN1x5Oz04k1kZTOnM4bgn0oZb7Og==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/hapi-pino/-/hapi-pino-6.1.0.tgz",
+      "integrity": "sha512-LP/hfRj2WCWg8QRjPt+FZzhnnDP+h28NkdLlNn0RbtAHp28ZynqHzF3hxjl+mJdl8mwo2L4DOw91uMsi+6V7Qg==",
       "requires": {
-        "@hapi/hoek": "^6.2.4",
+        "@hapi/hoek": "^8.2.2",
         "abstract-logging": "^1.0.0",
-        "pino": "^5.13.1",
-        "pino-pretty": "^2.6.1"
+        "pino": "^5.13.2",
+        "pino-pretty": "^3.2.1"
       }
     },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -3194,8 +3358,7 @@
     "has-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
-      "dev": true
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
     },
     "has-yarn": {
       "version": "2.1.0",
@@ -3346,9 +3509,9 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
-      "integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+      "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^3.2.0",
@@ -3371,6 +3534,40 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^2.0.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+          "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "dev": true,
+          "requires": {
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
+          }
         },
         "string-width": {
           "version": "2.1.1",
@@ -3429,9 +3626,9 @@
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "ip-address": {
-      "version": "5.9.4",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-5.9.4.tgz",
-      "integrity": "sha512-dHkI3/YNJq4b/qQaz+c8LuarD3pY24JqZWfjB8aZx1gtpc2MDILu9L9jpZe1sHpzo/yWFweQVn+U//FhazUxmw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-6.1.0.tgz",
+      "integrity": "sha512-u9YYtb1p2fWSbzpKmZ/b3QXWA+diRYPxc2c4y5lFB/MMk5WZ7wNZv8S3CFcIGVJ5XtlaCAl/FQy/D3eQ2XtdOA==",
       "requires": {
         "jsbn": "1.1.0",
         "lodash": "^4.17.15",
@@ -3444,18 +3641,18 @@
       "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
     },
     "ipfs": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.37.0.tgz",
-      "integrity": "sha512-nZb/qMmq3G1IswN2g2DL9u/mdRMND5WvgChmcDiq4Z0zyntLTaCMgwnXDAnCwhXyMLanY8AlGh42nq+DQoc51A==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.38.0.tgz",
+      "integrity": "sha512-Yt4bTEqJ32zml6FbTIaEUZS4Wo8MI97Q/fqU3TgbflKln5YEY7nXcr4Y/fzC/2n6jZG7j7XZsP0LFM557WJ+Fw==",
       "requires": {
-        "@hapi/ammo": "^3.1.0",
-        "@hapi/boom": "^7.4.2",
-        "@hapi/hapi": "^18.3.1",
+        "@hapi/ammo": "^3.1.1",
+        "@hapi/boom": "^7.4.3",
+        "@hapi/hapi": "^18.3.2",
         "@hapi/joi": "^15.0.1",
         "array-shuffle": "^1.0.1",
         "async": "^2.6.1",
         "async-iterator-all": "^1.0.0",
-        "async-iterator-to-pull-stream": "^1.1.0",
+        "async-iterator-to-pull-stream": "^1.3.0",
         "async-iterator-to-stream": "^1.1.0",
         "base32.js": "~0.1.0",
         "bignumber.js": "^9.0.0",
@@ -3464,7 +3661,6 @@
         "bs58": "^4.0.1",
         "buffer-peek-stream": "^1.0.1",
         "byteman": "^1.3.5",
-        "callbackify": "^1.1.0",
         "cid-tool": "~0.3.0",
         "cids": "~0.7.1",
         "class-is": "^1.1.0",
@@ -3473,27 +3669,28 @@
         "debug": "^4.1.0",
         "dlv": "^1.1.3",
         "err-code": "^2.0.0",
+        "explain-error": "^1.0.4",
         "file-type": "^12.0.1",
         "fnv1a": "^1.0.1",
         "fsm-event": "^2.1.0",
         "get-folder-size": "^2.0.0",
         "glob": "^7.1.3",
-        "hapi-pino": "^6.0.0",
+        "hapi-pino": "^6.1.0",
         "hashlru": "^2.3.0",
         "human-to-milliseconds": "^2.0.0",
         "interface-datastore": "~0.6.0",
         "ipfs-bitswap": "~0.25.1",
         "ipfs-block": "~0.8.1",
         "ipfs-block-service": "~0.15.2",
-        "ipfs-http-client": "^33.1.0",
+        "ipfs-http-client": "^37.0.1",
         "ipfs-http-response": "~0.3.1",
-        "ipfs-mfs": "~0.12.0",
-        "ipfs-multipart": "~0.1.1",
+        "ipfs-mfs": "^0.12.2",
+        "ipfs-multipart": "^0.2.0",
         "ipfs-repo": "~0.26.6",
         "ipfs-unixfs": "~0.1.16",
         "ipfs-unixfs-exporter": "~0.37.7",
         "ipfs-unixfs-importer": "~0.39.11",
-        "ipfs-utils": "~0.0.4",
+        "ipfs-utils": "^0.3.0",
         "ipld": "~0.24.1",
         "ipld-bitcoin": "~0.3.0",
         "ipld-dag-cbor": "~0.15.0",
@@ -3508,30 +3705,34 @@
         "is-pull-stream": "~0.0.0",
         "is-stream": "^2.0.0",
         "iso-url": "~0.4.6",
-        "just-flatten-it": "^2.1.0",
+        "it-pipe": "^1.0.1",
+        "it-to-stream": "^0.1.1",
         "just-safe-set": "^2.1.0",
         "kind-of": "^6.0.2",
-        "libp2p": "~0.25.4",
+        "libp2p": "~0.26.1",
         "libp2p-bootstrap": "~0.9.3",
         "libp2p-crypto": "~0.16.0",
         "libp2p-delegated-content-routing": "^0.2.4",
         "libp2p-delegated-peer-routing": "^0.2.4",
+        "libp2p-floodsub": "^0.18.0",
+        "libp2p-gossipsub": "~0.0.5",
         "libp2p-kad-dht": "~0.15.3",
         "libp2p-keychain": "~0.4.2",
         "libp2p-mdns": "~0.12.0",
         "libp2p-record": "~0.6.3",
         "libp2p-secio": "~0.11.0",
-        "libp2p-tcp": "~0.13.0",
+        "libp2p-tcp": "~0.13.1",
         "libp2p-webrtc-star": "~0.16.0",
         "libp2p-websocket-star-multi": "~0.4.3",
-        "libp2p-websockets": "~0.12.2",
+        "libp2p-websockets": "~0.12.3",
         "lodash": "^4.17.15",
-        "mafmt": "^6.0.2",
+        "mafmt": "^6.0.10",
         "merge-options": "^1.0.1",
         "mime-types": "^2.1.21",
         "mkdirp": "~0.5.1",
+        "mortice": "^2.0.0",
         "multiaddr": "^6.1.0",
-        "multiaddr-to-uri": "^4.0.1",
+        "multiaddr-to-uri": "^5.0.0",
         "multibase": "~0.6.0",
         "multicodec": "~0.5.5",
         "multihashes": "~0.4.14",
@@ -3543,6 +3744,7 @@
         "progress": "^2.0.1",
         "prom-client": "^11.5.3",
         "prometheus-gc-stats": "~0.6.0",
+        "promise-nodeify": "^3.0.1",
         "promisify-es6": "^1.0.3",
         "protons": "^1.0.1",
         "pull-abortable": "^4.1.1",
@@ -3553,7 +3755,7 @@
         "pull-ndjson": "~0.1.1",
         "pull-pushable": "^2.2.0",
         "pull-sort": "^1.0.1",
-        "pull-stream": "^3.6.13",
+        "pull-stream": "^3.6.14",
         "pull-stream-to-async-iterator": "^1.0.2",
         "pull-stream-to-stream": "^1.3.4",
         "pull-traverse": "^1.0.3",
@@ -3561,13 +3763,13 @@
         "receptacle": "^1.3.2",
         "semver": "^6.3.0",
         "stream-to-pull-stream": "^1.7.3",
-        "superstruct": "~0.6.0",
+        "superstruct": "~0.6.2",
         "tar-stream": "^2.0.0",
         "temp": "~0.9.0",
         "update-notifier": "^3.0.1",
         "uri-to-multiaddr": "^3.0.1",
         "varint": "^5.0.0",
-        "yargs": "^13.3.0",
+        "yargs": "^14.0.0",
         "yargs-promise": "^1.1.0"
       }
     },
@@ -3629,25 +3831,32 @@
       }
     },
     "ipfs-http-client": {
-      "version": "33.1.1",
-      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-33.1.1.tgz",
-      "integrity": "sha512-iwtLL3lOIzxXJFwLnOEtFUv1cYTuWJ0NauD7rpMEd/y4C7z6fuN6TSF4h547lxMh7sJWv+6Z0PmOA5N8FzUHJw==",
+      "version": "37.0.3",
+      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-37.0.3.tgz",
+      "integrity": "sha512-yv8lVWGUWcAX5K1K5gj0uWjIBmvbS0hIhnStC4Da+RTJL09jFj9LsBYySst8F3pmU6XfqOurwihlFmK79ZChyg==",
       "requires": {
+        "abort-controller": "^3.0.0",
         "async": "^2.6.1",
+        "async-iterator-all": "^1.0.0",
+        "async-iterator-to-pull-stream": "^1.3.0",
         "bignumber.js": "^9.0.0",
         "bl": "^3.0.0",
         "bs58": "^4.0.1",
-        "buffer": "^5.2.1",
+        "buffer": "^5.4.2",
         "cids": "~0.7.1",
         "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
         "debug": "^4.1.0",
+        "delay": "^4.3.0",
         "detect-node": "^2.0.4",
         "end-of-stream": "^1.4.1",
-        "err-code": "^1.1.2",
+        "err-code": "^2.0.0",
+        "explain-error": "^1.0.4",
         "flatmap": "0.0.3",
+        "form-data": "^2.5.1",
+        "fs-extra": "^8.1.0",
         "glob": "^7.1.3",
         "ipfs-block": "~0.8.1",
-        "ipfs-utils": "~0.0.3",
+        "ipfs-utils": "^0.4.0",
         "ipld-dag-cbor": "~0.15.0",
         "ipld-dag-pb": "~0.17.3",
         "ipld-raw": "^4.0.0",
@@ -3656,21 +3865,29 @@
         "is-stream": "^2.0.0",
         "iso-stream-http": "~0.1.2",
         "iso-url": "~0.4.6",
+        "it-glob": "0.0.4",
+        "it-to-stream": "^0.1.1",
+        "iterable-ndjson": "^1.1.0",
         "just-kebab-case": "^1.1.0",
         "just-map-keys": "^1.1.0",
         "kind-of": "^6.0.2",
+        "ky": "^0.14.0",
+        "ky-universal": "^0.3.0",
         "lru-cache": "^5.1.1",
+        "merge-options": "^1.0.1",
         "multiaddr": "^6.0.6",
         "multibase": "~0.6.0",
         "multicodec": "~0.5.1",
         "multihashes": "~0.4.14",
         "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
         "once": "^1.4.0",
-        "peer-id": "~0.12.2",
+        "peer-id": "~0.12.3",
         "peer-info": "~0.15.1",
+        "promise-nodeify": "^3.0.1",
         "promisify-es6": "^1.0.3",
         "pull-defer": "~0.2.3",
         "pull-stream": "^3.6.9",
+        "pull-stream-to-async-iterator": "^1.0.2",
         "pull-to-stream": "~0.1.1",
         "pump": "^3.0.0",
         "qs": "^6.5.2",
@@ -3680,10 +3897,23 @@
         "through2": "^3.0.1"
       },
       "dependencies": {
-        "err-code": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
-          "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
+        "ipfs-utils": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-0.4.0.tgz",
+          "integrity": "sha512-JLFmCcA058knmYiSB+WBw6nxcDHFS6p05weQOTFR/edufYot0UpgsJTcoMd1fHMq81n0nciJ3QQBqLcJxqGqhA==",
+          "requires": {
+            "buffer": "^5.2.1",
+            "err-code": "^2.0.0",
+            "fs-extra": "^8.1.0",
+            "is-buffer": "^2.0.3",
+            "is-electron": "^2.2.0",
+            "is-pull-stream": "0.0.0",
+            "is-stream": "^2.0.0",
+            "it-glob": "0.0.4",
+            "kind-of": "^6.0.2",
+            "pull-stream-to-async-iterator": "^1.0.2",
+            "readable-stream": "^3.4.0"
+          }
         }
       }
     },
@@ -3713,9 +3943,9 @@
       }
     },
     "ipfs-mfs": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/ipfs-mfs/-/ipfs-mfs-0.12.0.tgz",
-      "integrity": "sha512-EY+At/kw2Lsyfd/AFInmvR2O6MQvQ87RWhAnN3GXSy/tXaopaS5CqT9SSUVAx3we87/pAUbusxQ1pK7HYtrXSw==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/ipfs-mfs/-/ipfs-mfs-0.12.2.tgz",
+      "integrity": "sha512-o9vGKEdUI4HwQV67DQnC1AVSSs7i/yaIHrKPEb6Oe6vGeobLGuEGMReWjTcnMi5KAKUECFESEVtDuNJDr8BW5Q==",
       "requires": {
         "@hapi/boom": "^7.4.2",
         "@hapi/joi": "^15.1.0",
@@ -3725,13 +3955,13 @@
         "err-code": "^1.1.2",
         "hamt-sharding": "~0.0.2",
         "interface-datastore": "~0.6.0",
-        "ipfs-multipart": "~0.1.0",
+        "ipfs-multipart": "~0.2.0",
         "ipfs-unixfs": "~0.1.16",
         "ipfs-unixfs-exporter": "~0.37.6",
         "ipfs-unixfs-importer": "~0.39.9",
         "ipld-dag-pb": "~0.17.2",
         "joi-browser": "^13.4.0",
-        "mortice": "^1.2.1",
+        "mortice": "^2.0.0",
         "multicodec": "~0.5.3",
         "multihashes": "~0.4.14",
         "once": "^1.4.0",
@@ -3747,18 +3977,18 @@
       }
     },
     "ipfs-multipart": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ipfs-multipart/-/ipfs-multipart-0.1.1.tgz",
-      "integrity": "sha512-NAmCxgBkZ0usWXf8lMwYYEXvyzrqa65uy/1caVKm5yOKFoqXNrNOt4Ev99Pb+B0RMRqGSdfSvtnZM1cfhSSk2A==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ipfs-multipart/-/ipfs-multipart-0.2.0.tgz",
+      "integrity": "sha512-pDCr7xtOW7KCqgeGmejfWjm5xPH516Kx4OU/PdbtIZu68/cFPW4jftJy9idQHdf0C/NnKHnqntMY93rbc+qrQg==",
       "requires": {
         "@hapi/content": "^4.1.0",
-        "dicer": "~0.3.0"
+        "it-multipart": "~0.0.2"
       }
     },
     "ipfs-provider": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/ipfs-provider/-/ipfs-provider-0.2.1.tgz",
-      "integrity": "sha512-Z1AHl+LFif+S9y0YxmyWiqzvjjVm3mhWY/wNywymmekOklIUNDphHioxjJFjTvGfjPOJGMOZLRvX7Q4cJFhc8w==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/ipfs-provider/-/ipfs-provider-0.2.2.tgz",
+      "integrity": "sha512-Wf1yaSu1nwK7002c4oUgEQc2ajT6fGxHrhsxgQXFlcVGfHiWS0ygKqazmasSyuivj/J45rZfraXcy7wTmeXYdA==",
       "requires": {
         "ipfs-http-client": "^32.0.1",
         "multiaddr": "^6.0.6",
@@ -3825,6 +4055,20 @@
             "stream-to-pull-stream": "^1.7.2",
             "tar-stream": "^2.0.1",
             "through2": "^3.0.1"
+          }
+        },
+        "ipfs-utils": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-0.0.4.tgz",
+          "integrity": "sha512-7cZf6aGj2FG3XJWhCNwn4mS93Q0GEWjtBZvEHqzgI43U2qzNDCyzfS1pei1Y5F+tw/zDJ5U4XG0G9reJxR53Ig==",
+          "requires": {
+            "buffer": "^5.2.1",
+            "is-buffer": "^2.0.3",
+            "is-electron": "^2.2.0",
+            "is-pull-stream": "0.0.0",
+            "is-stream": "^2.0.0",
+            "kind-of": "^6.0.2",
+            "readable-stream": "^3.4.0"
           }
         }
       }
@@ -3929,16 +4173,20 @@
       }
     },
     "ipfs-utils": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-0.0.4.tgz",
-      "integrity": "sha512-7cZf6aGj2FG3XJWhCNwn4mS93Q0GEWjtBZvEHqzgI43U2qzNDCyzfS1pei1Y5F+tw/zDJ5U4XG0G9reJxR53Ig==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-0.3.0.tgz",
+      "integrity": "sha512-5xrOYv27lA8gV13K6Zm8gIUvNtqwmHCqztxnVE4S6aTdfMNkXQJJhRvlsi7RN/auHMORPxc3qSRMukgEUO3C2Q==",
       "requires": {
         "buffer": "^5.2.1",
+        "err-code": "^2.0.0",
+        "fs-extra": "^8.1.0",
         "is-buffer": "^2.0.3",
         "is-electron": "^2.2.0",
         "is-pull-stream": "0.0.0",
         "is-stream": "^2.0.0",
+        "it-glob": "0.0.4",
         "kind-of": "^6.0.2",
+        "pull-stream-to-async-iterator": "^1.0.2",
         "readable-stream": "^3.4.0"
       }
     },
@@ -4207,15 +4455,14 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-buffer": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-      "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
     },
     "is-callable": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
-      "dev": true
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
     },
     "is-ci": {
       "version": "2.0.0",
@@ -4233,8 +4480,7 @@
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-      "dev": true
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
     "is-domain-name": {
       "version": "1.0.1",
@@ -4289,6 +4535,11 @@
         "global-dirs": "^0.1.0",
         "is-path-inside": "^1.0.0"
       }
+    },
+    "is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w=="
     },
     "is-ip": {
       "version": "2.0.0",
@@ -4356,7 +4607,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true,
       "requires": {
         "has": "^1.0.1"
       }
@@ -4370,7 +4620,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.0"
       }
@@ -4391,9 +4640,13 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "iso-random-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/iso-random-stream/-/iso-random-stream-1.1.0.tgz",
-      "integrity": "sha512-ywSWt0KrWcsaK0jVoVJIR30rLyjg9Rw3k2Sm/qp+3tdtSV0SNH7L7KilKnENcENOSoJxDFvpt2idvuMMQohdCQ=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/iso-random-stream/-/iso-random-stream-1.1.1.tgz",
+      "integrity": "sha512-YEt/7xOwTdu4KXIgtdgGFkiLUsBaddbnkmHyaFdjJYIcD7V4gpQHPvYC5tyh3kA0PQ01y9lWm1ruVdf8Mqzovg==",
+      "requires": {
+        "buffer": "^5.4.3",
+        "readable-stream": "^3.4.0"
+      }
     },
     "iso-stream-http": {
       "version": "0.1.2",
@@ -4414,6 +4667,50 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+    },
+    "it-glob": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.4.tgz",
+      "integrity": "sha512-sTMM62VQWRqlMpgbd+x1uTviQY7a8vMLXYmw+KPiV9vmAYuyIr9Sp1QRQ5B/faybf4O9RzMGyQb7eFpqLwsBhQ==",
+      "requires": {
+        "fs-extra": "^8.1.0",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "it-multipart": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/it-multipart/-/it-multipart-0.0.2.tgz",
+      "integrity": "sha512-Mlvf1Tt+gLyk5EkE9njjfDCuvf5+3rx1vDt271MT7Ye08/3yJL/h+M/EWhPBPLebmNrkfXUQOGl8ud4T9PzuWA==",
+      "requires": {
+        "buffer-indexof": "^1.1.1",
+        "parse-headers": "^2.0.2"
+      }
+    },
+    "it-pipe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-1.0.1.tgz",
+      "integrity": "sha512-clx7NMIf4eXe3rp4dKLmT5vMYv/hvZv4lNi1/xx4ZJ8CFmpGod9rTKisyBNBTurbCEa3a7503COankdBj/uUCA=="
+    },
+    "it-to-stream": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/it-to-stream/-/it-to-stream-0.1.1.tgz",
+      "integrity": "sha512-QQx/58JBvT189imr6fD234F8aVf8EdyQHJR0MxXAOShEWK1NWyahPYIQt/tQG7PId0ZG/6/3tUiVCfw2cq+e1w==",
+      "requires": {
+        "buffer": "^5.2.1",
+        "fast-fifo": "^1.0.0",
+        "get-iterator": "^1.0.2",
+        "p-defer": "^3.0.0",
+        "p-fifo": "^1.0.0",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "iterable-ndjson": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/iterable-ndjson/-/iterable-ndjson-1.1.0.tgz",
+      "integrity": "sha512-OOp1Lb0o3k5MkXHx1YaIY5Z0ELosZfTnBaas9f8opJVcZGBIONA2zY/6CYE+LKkqrSDooIneZbrBGgOZnHPkrg==",
+      "requires": {
+        "string_decoder": "^1.2.0"
+      }
     },
     "jmespath": {
       "version": "0.15.0",
@@ -4486,6 +4783,14 @@
         "delimit-stream": "0.1.0"
       }
     },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "jsx-ast-utils": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.1.tgz",
@@ -4501,10 +4806,10 @@
       "resolved": "https://registry.npmjs.org/just-debounce-it/-/just-debounce-it-1.1.0.tgz",
       "integrity": "sha512-87Nnc0qZKgBZuhFZjYVjSraic0x7zwjhaTMrCKlj0QYKH6lh0KbFzVnfu6LHan03NO7J8ygjeBeD0epejn5Zcg=="
     },
-    "just-flatten-it": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/just-flatten-it/-/just-flatten-it-2.1.0.tgz",
-      "integrity": "sha512-mX3NUt/LF6EzohLJZXhywCwz2zqdhx6wVkEu6UfUx00lVQlSB6SBV1O+/Le15NfsimrWRD82H69ZkSVQZffhmw=="
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw=="
     },
     "just-kebab-case": {
       "version": "1.1.0",
@@ -4557,6 +4862,20 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
       "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+    },
+    "ky": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-0.14.0.tgz",
+      "integrity": "sha512-NSjg+WCElQPdlF3BFZnjh8s5QlMIP+vIGoyukrRU+n+23VBUX87bQYOoG5h3HX5tO7kKQYXvg+QZVt8n0uWmhg=="
+    },
+    "ky-universal": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ky-universal/-/ky-universal-0.3.0.tgz",
+      "integrity": "sha512-CM4Bgb2zZZpsprcjI6DNYTaH3oGHXL2u7BU4DK+lfCuC4snkt9/WRpMYeKbBbXscvKkeqBwzzjFX2WwmKY5K/A==",
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "node-fetch": "^2.6.0"
+      }
     },
     "latency-monitor": {
       "version": "0.2.1",
@@ -4677,6 +4996,11 @@
             "ltgt": "~2.2.0",
             "safe-buffer": "~5.1.1"
           }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
     },
@@ -4753,6 +5077,11 @@
             "util-deprecate": "~1.0.1"
           }
         },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -4761,6 +5090,14 @@
             "safe-buffer": "~5.1.0"
           }
         }
+      }
+    },
+    "level-supports": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.0.tgz",
+      "integrity": "sha512-01PKZumFhgysuHUbRz4c9DyA1egmcHJBAsZbm0Vf5agojC3uWOvAnhOD4swNUgHlfJBymXLi/xkBaEckeNRSvA==",
+      "requires": {
+        "xtend": "^4.0.2"
       }
     },
     "level-ws": {
@@ -4776,6 +5113,11 @@
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "object-keys": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
         },
         "readable-stream": {
           "version": "1.0.34",
@@ -4804,23 +5146,35 @@
       }
     },
     "leveldown": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-5.1.1.tgz",
-      "integrity": "sha512-4n2R/vEA/sssh5TKtFwM9gshW2tirNoURLqekLRUUzuF+eUBLFAufO8UW7bz8lBbG2jw8tQDF3LC+LcUCc12kg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-5.3.0.tgz",
+      "integrity": "sha512-PQXwTKMz55rYlg7984VbM7xpcqdiWgVKRms2fEgqVL7spd6+wK8NewScJOYIGpIG7/XxMOc0i+q/NX0WLJEcwA==",
       "requires": {
-        "abstract-leveldown": "~6.0.3",
-        "napi-macros": "~1.8.1",
+        "abstract-leveldown": "~6.1.1",
+        "napi-macros": "~2.0.0",
         "node-gyp-build": "~4.1.0"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.1.1.tgz",
+          "integrity": "sha512-7fK/KySVqzKIomdhkSWzX4YBQhzkzEMbWSiaB6mSN9e+ZdV3KEeKxia/8xQzCkATA5xnnukdP88cFR0D2FsFXw==",
+          "requires": {
+            "level-concat-iterator": "~2.0.0",
+            "xtend": "~4.0.0"
+          }
+        }
       }
     },
     "levelup": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/levelup/-/levelup-4.1.0.tgz",
-      "integrity": "sha512-+Qhe2/jb5affN7BeFgWUUWVdYoGXO2nFS3QLEZKZynnQyP9xqA+7wgOz3fD8SST2UKpHQuZgjyJjTcB2nMl2dQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-4.3.2.tgz",
+      "integrity": "sha512-cRTjU4ktWo59wf13PHEiOayHC3n0dOh4i5+FHr4tv4MX9+l7mqETicNq3Aj07HKlLdk0z5muVoDL2RD+ovgiyA==",
       "requires": {
-        "deferred-leveldown": "~5.1.0",
+        "deferred-leveldown": "~5.3.0",
         "level-errors": "~2.0.0",
         "level-iterator-stream": "~4.0.0",
+        "level-supports": "~1.0.0",
         "xtend": "~4.0.0"
       }
     },
@@ -4840,26 +5194,40 @@
       }
     },
     "libp2p": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.25.5.tgz",
-      "integrity": "sha512-vkUGFkPcY7t/LyyIbjKbF7KE4O+gPmJXvv363TjmNSZX/ph0aP8KtCpurxwo82ztxec3w5XCZUyNGrjEliSshw==",
+      "version": "0.26.2",
+      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.26.2.tgz",
+      "integrity": "sha512-AaPSpROjrg17QBMood6tdxLj3yWH5qR/pnQ4gurz3byvYvD6Tw3yt7PQRdSyjOh6Oh+EX06yTrNCnoDTdgliKg==",
       "requires": {
         "async": "^2.6.2",
+        "bignumber.js": "^9.0.0",
+        "class-is": "^1.1.0",
         "debug": "^4.1.1",
         "err-code": "^1.1.2",
         "fsm-event": "^2.1.0",
-        "libp2p-connection-manager": "^0.1.0",
-        "libp2p-floodsub": "^0.16.1",
-        "libp2p-ping": "^0.8.5",
-        "libp2p-switch": "^0.42.12",
+        "hashlru": "^2.3.0",
+        "interface-connection": "~0.3.3",
+        "latency-monitor": "~0.2.1",
+        "libp2p-crypto": "~0.16.1",
         "libp2p-websockets": "^0.12.2",
         "mafmt": "^6.0.7",
+        "merge-options": "^1.0.1",
+        "moving-average": "^1.0.0",
         "multiaddr": "^6.1.0",
+        "multistream-select": "~0.14.6",
         "once": "^1.4.0",
         "peer-book": "^0.9.1",
         "peer-id": "^0.12.2",
-        "peer-info": "^0.15.1",
-        "superstruct": "^0.6.0"
+        "peer-info": "~0.15.1",
+        "promisify-es6": "^1.0.3",
+        "protons": "^1.0.1",
+        "pull-cat": "^1.1.11",
+        "pull-defer": "~0.2.3",
+        "pull-handshake": "^1.1.4",
+        "pull-reader": "^1.3.1",
+        "pull-stream": "^3.6.9",
+        "retimer": "^2.0.0",
+        "superstruct": "^0.6.0",
+        "xsalsa20": "^1.0.2"
       },
       "dependencies": {
         "err-code": {
@@ -4882,39 +5250,10 @@
         "peer-info": "~0.15.1"
       }
     },
-    "libp2p-circuit": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/libp2p-circuit/-/libp2p-circuit-0.3.7.tgz",
-      "integrity": "sha512-Z14T3D1YYE1W2k9QtheyxzfwGpEi4Tk4gDofSmAhKqlfCQcctNvKdv0udgjnwzZjXRBtAmNzVJfxZ2WagtZotA==",
-      "requires": {
-        "async": "^2.6.2",
-        "debug": "^4.1.1",
-        "interface-connection": "~0.3.3",
-        "mafmt": "^6.0.7",
-        "multiaddr": "^6.0.6",
-        "once": "^1.4.0",
-        "peer-id": "~0.12.2",
-        "peer-info": "~0.15.1",
-        "protons": "^1.0.1",
-        "pull-handshake": "^1.1.4",
-        "pull-length-prefixed": "^1.3.2",
-        "pull-pair": "^1.1.0",
-        "pull-stream": "^3.6.9"
-      }
-    },
-    "libp2p-connection-manager": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/libp2p-connection-manager/-/libp2p-connection-manager-0.1.0.tgz",
-      "integrity": "sha512-Md5UERlkD+KUsdUQRJE+B+UBq/KwOTo650z8Bl0zEfKjfnv/yMeFhucnf14suYBnzIIdGsckYn66xbeki31BLw==",
-      "requires": {
-        "debug": "^4.1.1",
-        "latency-monitor": "~0.2.1"
-      }
-    },
     "libp2p-crypto": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.16.1.tgz",
-      "integrity": "sha512-+fxqy+cDjwOKK4KTj44WQmjPE5ep2eR5uAIQWHl/+RKvRSor3+RAY53VWkAecgAEvjX2AswxBsoCIJK1Qk5aIQ==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.16.2.tgz",
+      "integrity": "sha512-eAml9loxnr5j2uroI3Oy/9oJrVrAPqUSVmcTftkES1p+RMg1uSSfiExCROQJfSde17aKqGzCduQTDrYXpsRhDA==",
       "requires": {
         "asmcrypto.js": "^2.3.2",
         "asn1.js": "^5.0.1",
@@ -4926,12 +5265,12 @@
         "keypair": "^1.0.1",
         "libp2p-crypto-secp256k1": "~0.3.0",
         "multihashing-async": "~0.5.1",
-        "node-forge": "~0.7.6",
+        "node-forge": "^0.8.5",
         "pem-jwk": "^2.0.0",
         "protons": "^1.0.1",
         "rsa-pem-to-jwk": "^1.1.3",
         "tweetnacl": "^1.0.0",
-        "ursa-optional": "~0.9.10"
+        "ursa-optional": "~0.10.0"
       },
       "dependencies": {
         "multihashing-async": {
@@ -4974,18 +5313,75 @@
         "peer-info": "^0.15.1"
       },
       "dependencies": {
-        "eventemitter3": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
-          "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
+        "err-code": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+          "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
         },
-        "p-queue": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.1.0.tgz",
-          "integrity": "sha512-907vNz/cY+JEsqGglo7o/Ia9E/wisahJGOp9HPfbAyCVGERQVmFGA4IyknxY1v+QRBiMKedL3ToOBXNEy9MKQA==",
+        "ipfs-http-client": {
+          "version": "33.1.1",
+          "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-33.1.1.tgz",
+          "integrity": "sha512-iwtLL3lOIzxXJFwLnOEtFUv1cYTuWJ0NauD7rpMEd/y4C7z6fuN6TSF4h547lxMh7sJWv+6Z0PmOA5N8FzUHJw==",
           "requires": {
-            "eventemitter3": "^4.0.0",
-            "p-timeout": "^3.1.0"
+            "async": "^2.6.1",
+            "bignumber.js": "^9.0.0",
+            "bl": "^3.0.0",
+            "bs58": "^4.0.1",
+            "buffer": "^5.2.1",
+            "cids": "~0.7.1",
+            "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
+            "debug": "^4.1.0",
+            "detect-node": "^2.0.4",
+            "end-of-stream": "^1.4.1",
+            "err-code": "^1.1.2",
+            "flatmap": "0.0.3",
+            "glob": "^7.1.3",
+            "ipfs-block": "~0.8.1",
+            "ipfs-utils": "~0.0.3",
+            "ipld-dag-cbor": "~0.15.0",
+            "ipld-dag-pb": "~0.17.3",
+            "ipld-raw": "^4.0.0",
+            "is-ipfs": "~0.6.1",
+            "is-pull-stream": "0.0.0",
+            "is-stream": "^2.0.0",
+            "iso-stream-http": "~0.1.2",
+            "iso-url": "~0.4.6",
+            "just-kebab-case": "^1.1.0",
+            "just-map-keys": "^1.1.0",
+            "kind-of": "^6.0.2",
+            "lru-cache": "^5.1.1",
+            "multiaddr": "^6.0.6",
+            "multibase": "~0.6.0",
+            "multicodec": "~0.5.1",
+            "multihashes": "~0.4.14",
+            "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
+            "once": "^1.4.0",
+            "peer-id": "~0.12.2",
+            "peer-info": "~0.15.1",
+            "promisify-es6": "^1.0.3",
+            "pull-defer": "~0.2.3",
+            "pull-stream": "^3.6.9",
+            "pull-to-stream": "~0.1.1",
+            "pump": "^3.0.0",
+            "qs": "^6.5.2",
+            "readable-stream": "^3.1.1",
+            "stream-to-pull-stream": "^1.7.2",
+            "tar-stream": "^2.0.1",
+            "through2": "^3.0.1"
+          }
+        },
+        "ipfs-utils": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-0.0.4.tgz",
+          "integrity": "sha512-7cZf6aGj2FG3XJWhCNwn4mS93Q0GEWjtBZvEHqzgI43U2qzNDCyzfS1pei1Y5F+tw/zDJ5U4XG0G9reJxR53Ig==",
+          "requires": {
+            "buffer": "^5.2.1",
+            "is-buffer": "^2.0.3",
+            "is-electron": "^2.2.0",
+            "is-pull-stream": "0.0.0",
+            "is-stream": "^2.0.0",
+            "kind-of": "^6.0.2",
+            "readable-stream": "^3.4.0"
           }
         }
       }
@@ -5001,50 +5397,135 @@
         "peer-info": "^0.15.1"
       },
       "dependencies": {
-        "eventemitter3": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
-          "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
+        "err-code": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+          "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
         },
-        "p-queue": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.1.0.tgz",
-          "integrity": "sha512-907vNz/cY+JEsqGglo7o/Ia9E/wisahJGOp9HPfbAyCVGERQVmFGA4IyknxY1v+QRBiMKedL3ToOBXNEy9MKQA==",
+        "ipfs-http-client": {
+          "version": "33.1.1",
+          "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-33.1.1.tgz",
+          "integrity": "sha512-iwtLL3lOIzxXJFwLnOEtFUv1cYTuWJ0NauD7rpMEd/y4C7z6fuN6TSF4h547lxMh7sJWv+6Z0PmOA5N8FzUHJw==",
           "requires": {
-            "eventemitter3": "^4.0.0",
-            "p-timeout": "^3.1.0"
+            "async": "^2.6.1",
+            "bignumber.js": "^9.0.0",
+            "bl": "^3.0.0",
+            "bs58": "^4.0.1",
+            "buffer": "^5.2.1",
+            "cids": "~0.7.1",
+            "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
+            "debug": "^4.1.0",
+            "detect-node": "^2.0.4",
+            "end-of-stream": "^1.4.1",
+            "err-code": "^1.1.2",
+            "flatmap": "0.0.3",
+            "glob": "^7.1.3",
+            "ipfs-block": "~0.8.1",
+            "ipfs-utils": "~0.0.3",
+            "ipld-dag-cbor": "~0.15.0",
+            "ipld-dag-pb": "~0.17.3",
+            "ipld-raw": "^4.0.0",
+            "is-ipfs": "~0.6.1",
+            "is-pull-stream": "0.0.0",
+            "is-stream": "^2.0.0",
+            "iso-stream-http": "~0.1.2",
+            "iso-url": "~0.4.6",
+            "just-kebab-case": "^1.1.0",
+            "just-map-keys": "^1.1.0",
+            "kind-of": "^6.0.2",
+            "lru-cache": "^5.1.1",
+            "multiaddr": "^6.0.6",
+            "multibase": "~0.6.0",
+            "multicodec": "~0.5.1",
+            "multihashes": "~0.4.14",
+            "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
+            "once": "^1.4.0",
+            "peer-id": "~0.12.2",
+            "peer-info": "~0.15.1",
+            "promisify-es6": "^1.0.3",
+            "pull-defer": "~0.2.3",
+            "pull-stream": "^3.6.9",
+            "pull-to-stream": "~0.1.1",
+            "pump": "^3.0.0",
+            "qs": "^6.5.2",
+            "readable-stream": "^3.1.1",
+            "stream-to-pull-stream": "^1.7.2",
+            "tar-stream": "^2.0.1",
+            "through2": "^3.0.1"
+          }
+        },
+        "ipfs-utils": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-0.0.4.tgz",
+          "integrity": "sha512-7cZf6aGj2FG3XJWhCNwn4mS93Q0GEWjtBZvEHqzgI43U2qzNDCyzfS1pei1Y5F+tw/zDJ5U4XG0G9reJxR53Ig==",
+          "requires": {
+            "buffer": "^5.2.1",
+            "is-buffer": "^2.0.3",
+            "is-electron": "^2.2.0",
+            "is-pull-stream": "0.0.0",
+            "is-stream": "^2.0.0",
+            "kind-of": "^6.0.2",
+            "readable-stream": "^3.4.0"
           }
         }
       }
     },
     "libp2p-floodsub": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/libp2p-floodsub/-/libp2p-floodsub-0.16.1.tgz",
-      "integrity": "sha512-3Y+BMwlgit5LGKFUwEn5hNH9+WvhK4mkSEKe7mu0xtQ0KmFvwUpYt+UO/By1iZRpYDyEhQ8rya0ZJtYcqFkxvg==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/libp2p-floodsub/-/libp2p-floodsub-0.18.0.tgz",
+      "integrity": "sha512-4OihLP5A4LsxNPlfb0mq6vkjAaNu4YxuyYeoj2nNgrRSzr4H8Dz0YtA+DzEDXIgP2RBANSzS+KG9oDeUXDHa/Q==",
       "requires": {
         "async": "^2.6.2",
         "bs58": "^4.0.1",
         "debug": "^4.1.1",
         "length-prefixed-stream": "^2.0.0",
         "libp2p-crypto": "~0.16.1",
-        "libp2p-pubsub": "~0.1.0",
+        "libp2p-pubsub": "~0.2.0",
         "protons": "^1.0.1",
         "pull-length-prefixed": "^1.3.2",
         "pull-pushable": "^2.2.0",
         "pull-stream": "^3.6.9"
       }
     },
-    "libp2p-identify": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/libp2p-identify/-/libp2p-identify-0.7.6.tgz",
-      "integrity": "sha512-QleYqI6f8ah6G6sQU9uaIa9FVOtyp6LtiqopfjrmAIO5Oz22Zw+dpT7FcEXvYP7kL036Es2vzZm0js0pOWw1MA==",
+    "libp2p-gossipsub": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/libp2p-gossipsub/-/libp2p-gossipsub-0.0.5.tgz",
+      "integrity": "sha512-7IM9hcSkc7pBWEju/a5ZGcUrEHclgVoUU7XPrMsMB7s5QNXziSbLjJvIBlgU7WOxoTmgmZldEtHPkrsPEb1C9A==",
       "requires": {
-        "multiaddr": "^6.0.4",
+        "async": "^2.6.2",
+        "err-code": "^1.1.2",
+        "libp2p-floodsub": "~0.17.1",
+        "libp2p-pubsub": "~0.2.0",
+        "multistream-select": "~0.14.6",
         "peer-id": "~0.12.2",
         "peer-info": "~0.15.1",
         "protons": "^1.0.1",
-        "pull-length-prefixed": "^1.3.1",
-        "pull-stream": "^3.6.9"
+        "pull-length-prefixed": "^1.3.3",
+        "pull-stream": "^3.6.13"
+      },
+      "dependencies": {
+        "err-code": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+          "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
+        },
+        "libp2p-floodsub": {
+          "version": "0.17.2",
+          "resolved": "https://registry.npmjs.org/libp2p-floodsub/-/libp2p-floodsub-0.17.2.tgz",
+          "integrity": "sha512-xOljtBcNTerBwRYFnXlJVmTwdYla9YTvBux6HaBE0GvVjPHqOI7gO5WJQ1Nul/7h5qLX5tJqZ4OY5CVn+mcuUQ==",
+          "requires": {
+            "async": "^2.6.2",
+            "bs58": "^4.0.1",
+            "debug": "^4.1.1",
+            "length-prefixed-stream": "^2.0.0",
+            "libp2p-crypto": "~0.16.1",
+            "libp2p-pubsub": "~0.2.0",
+            "protons": "^1.0.1",
+            "pull-length-prefixed": "^1.3.2",
+            "pull-pushable": "^2.2.0",
+            "pull-stream": "^3.6.9"
+          }
+        }
       }
     },
     "libp2p-kad-dht": {
@@ -5089,6 +5570,11 @@
           "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
           "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
         },
+        "eventemitter3": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+          "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
+        },
         "multihashing-async": {
           "version": "0.5.2",
           "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.5.2.tgz",
@@ -5099,6 +5585,14 @@
             "multihashes": "~0.4.13",
             "murmurhash3js": "^3.0.1",
             "nodeify": "^1.0.1"
+          }
+        },
+        "p-queue": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-5.0.0.tgz",
+          "integrity": "sha512-6QfeouDf236N+MAxHch0CVIy8o/KBnmhttKjxZoOkUlzqU+u9rZgEyXH3OdckhTgawbqf5rpzmyR+07+Lv0+zg==",
+          "requires": {
+            "eventemitter3": "^3.1.0"
           }
         }
       }
@@ -5122,6 +5616,11 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
           "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
+        },
+        "node-forge": {
+          "version": "0.7.6",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
+          "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
         }
       }
     },
@@ -5139,20 +5638,10 @@
         "peer-info": "~0.15.1"
       }
     },
-    "libp2p-ping": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/libp2p-ping/-/libp2p-ping-0.8.5.tgz",
-      "integrity": "sha512-BzCN3+jp1SvJQZlXq2G3TMkyK5UOOf3JO+CZMnaUEHYlRgQf2zShYta5XU2IGx0EJA/23iCdCL+LjBP/DOvbkQ==",
-      "requires": {
-        "libp2p-crypto": "~0.16.0",
-        "pull-handshake": "^1.1.4",
-        "pull-stream": "^3.6.9"
-      }
-    },
     "libp2p-pubsub": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/libp2p-pubsub/-/libp2p-pubsub-0.1.0.tgz",
-      "integrity": "sha512-oppDCIZLmqODAgt1r625yO0j9wy7auro7B6/5bw2WN5ctqTsG791dn3SGVRLV8Dvd7uSfMlOaZ/Bkw8jle0Ytg==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/libp2p-pubsub/-/libp2p-pubsub-0.2.1.tgz",
+      "integrity": "sha512-6LFl7b/39LLWKK9v/Oz9F7+c0WX8t2W2Qf2nwyMMCtJDGxC3csvXdhWwUDzBwXx704BJhVgpsVVJ4fXQn5gahg==",
       "requires": {
         "async": "^2.6.2",
         "bs58": "^4.0.1",
@@ -5164,6 +5653,7 @@
         "pull-length-prefixed": "^1.3.1",
         "pull-pushable": "^2.2.0",
         "pull-stream": "^3.6.9",
+        "sinon": "^7.3.2",
         "time-cache": "~0.3.0"
       },
       "dependencies": {
@@ -5227,83 +5717,21 @@
         }
       }
     },
-    "libp2p-switch": {
-      "version": "0.42.12",
-      "resolved": "https://registry.npmjs.org/libp2p-switch/-/libp2p-switch-0.42.12.tgz",
-      "integrity": "sha512-aNjJQpP9kSClXXKIliSqIowIoxAy0JQ8hnw6BoqOHUIG9Eov4GVyuOdU6lQKl1ym4uKMsnF2G49qpZJ47O01XA==",
+    "libp2p-tcp": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.13.2.tgz",
+      "integrity": "sha512-TvHLCn25m+UIH+hXTuy8xJDU/Kxj8EEEgWzhWUImsrb/YsYFywjbuv8YCAYtTUMIzyT2DnTtM+xzPxccg/sytw==",
       "requires": {
-        "async": "^2.6.2",
-        "bignumber.js": "^8.1.1",
         "class-is": "^1.1.0",
         "debug": "^4.1.1",
-        "err-code": "^1.1.2",
-        "fsm-event": "^2.1.0",
-        "hashlru": "^2.3.0",
         "interface-connection": "~0.3.3",
-        "libp2p-circuit": "~0.3.6",
-        "libp2p-identify": "~0.7.6",
-        "moving-average": "^1.0.0",
-        "multiaddr": "^6.0.6",
-        "multistream-select": "~0.14.4",
-        "once": "^1.4.0",
-        "peer-id": "~0.12.2",
-        "peer-info": "~0.15.1",
-        "pull-stream": "^3.6.9",
-        "retimer": "^2.0.0"
-      },
-      "dependencies": {
-        "bignumber.js": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.1.1.tgz",
-          "integrity": "sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ=="
-        },
-        "err-code": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
-          "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
-        }
-      }
-    },
-    "libp2p-tcp": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.13.0.tgz",
-      "integrity": "sha512-bsmfxi+uVegK61x9UxBEgWtvujPl+zwzuVEyaVRs2IxHu6OE5MGKnj7AflzlK4e3w2HZn8nm4qwMV5m+fhqK1g==",
-      "requires": {
-        "class-is": "^1.1.0",
-        "debug": "^3.1.0",
-        "interface-connection": "~0.3.2",
-        "ip-address": "^5.8.9",
+        "ip-address": "^6.1.0",
         "lodash.includes": "^4.3.0",
         "lodash.isfunction": "^3.0.9",
-        "mafmt": "^6.0.2",
-        "multiaddr": "^5.0.0",
+        "mafmt": "^6.0.7",
+        "multiaddr": "^6.1.0",
         "once": "^1.4.0",
-        "stream-to-pull-stream": "^1.7.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "multiaddr": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-5.0.2.tgz",
-          "integrity": "sha512-dXz1chaUHV6L6okujDLS7uRA6NmCbitpikOJA0vMMnrwVyai5kC3ot2CSLrSfj3B8XIgNzpe/j5auSYrnbGGzA==",
-          "requires": {
-            "bs58": "^4.0.1",
-            "class-is": "^1.1.0",
-            "ip": "^1.1.5",
-            "ip-address": "^5.8.9",
-            "lodash.filter": "^4.6.0",
-            "lodash.map": "^4.6.0",
-            "varint": "^5.0.0",
-            "xtend": "^4.0.1"
-          }
-        }
+        "stream-to-pull-stream": "^1.7.3"
       }
     },
     "libp2p-webrtc-star": {
@@ -5367,15 +5795,15 @@
       }
     },
     "libp2p-websockets": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/libp2p-websockets/-/libp2p-websockets-0.12.2.tgz",
-      "integrity": "sha512-K/Jg/fWFfP5NyiLx01EJcoAcYQO00RSHpZfPQDR3May6ABvOseAjq45SrUDdDCW5mCS0502Vz1VjRrZdOXw8zQ==",
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/libp2p-websockets/-/libp2p-websockets-0.12.4.tgz",
+      "integrity": "sha512-wXrdFgBibvuD+b+s1KIvhlbzh/qCXSDBmzkoKUugftxV6tC5AhotbHW1JlcI726+U+z4k8ha3nEZd9PY64NLqQ==",
       "requires": {
         "class-is": "^1.1.0",
         "debug": "^4.1.1",
-        "interface-connection": "~0.3.2",
-        "mafmt": "^6.0.4",
-        "multiaddr-to-uri": "^4.0.1",
+        "interface-connection": "~0.3.3",
+        "mafmt": "^6.0.7",
+        "multiaddr-to-uri": "^5.0.0",
         "pull-ws": "github:hugomrdias/pull-ws#fix/bundle-size"
       }
     },
@@ -5404,11 +5832,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
-    "lodash.filter": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
-      "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4="
-    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -5424,23 +5847,23 @@
       "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
       "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw=="
     },
-    "lodash.map": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
-      "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM="
-    },
     "lodash.throttle": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
       "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
     },
     "log-symbols": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
       "requires": {
-        "chalk": "^2.0.1"
+        "chalk": "^2.4.2"
       }
+    },
+    "lolex": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
+      "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg=="
     },
     "long": {
       "version": "4.0.0",
@@ -5489,11 +5912,11 @@
       "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
     },
     "mafmt": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-6.0.7.tgz",
-      "integrity": "sha512-2OG/EGAJZmpZBl7YRT1hD83sZa2gKsUEdegRuURreIOe7B4VeHU1rYYmhgk7BkLzknGL3xGYsDx3bbSgEEzE7g==",
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-6.0.10.tgz",
+      "integrity": "sha512-FjHDnew6dW9lUu3eYwP0FvvJl9uvNbqfoJM+c1WJcSyutNEIlyu6v3f/rlPnD1cnmue38IjuHlhBdIh3btAiyw==",
       "requires": {
-        "multiaddr": "^6.0.4"
+        "multiaddr": "^6.1.0"
       }
     },
     "make-dir": {
@@ -5539,6 +5962,11 @@
           "requires": {
             "xtend": "~4.0.0"
           }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
     },
@@ -5626,6 +6054,11 @@
             }
           }
         },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -5637,9 +6070,9 @@
       }
     },
     "mime-db": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
+      "integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ=="
     },
     "mime-types": {
       "version": "2.1.24",
@@ -5647,12 +6080,19 @@
       "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
       "requires": {
         "mime-db": "1.40.0"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.40.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+          "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+        }
       }
     },
     "mimic-fn": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
     "mimic-response": {
       "version": "1.0.1",
@@ -5723,12 +6163,13 @@
       }
     },
     "mortice": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/mortice/-/mortice-1.2.2.tgz",
-      "integrity": "sha512-zECpP0bCFVxlAbIJST7ZHQPm5ECKsJRaw4JfSmu5XQeSkO+UB8i+1GUxkskqLHHQfj/wGRWNDd8KBkWfHaZZkw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mortice/-/mortice-2.0.0.tgz",
+      "integrity": "sha512-rXcjRgv2MRhpwGHErxKcDcp5IoA9CPvPFLXmmseQYIuQ2fSVu8tsMKi/eYUXzp/HH1s6y3IID/GwRqlSglDdRA==",
       "requires": {
+        "globalthis": "^1.0.0",
         "observable-webworkers": "^1.0.0",
-        "p-queue": "^5.0.0",
+        "p-queue": "^6.0.0",
         "promise-timeout": "^1.3.0",
         "shortid": "^2.2.8"
       }
@@ -5749,9 +6190,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multiaddr": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-6.1.0.tgz",
-      "integrity": "sha512-+XTP3OzG2m6JVcjxA9QBmGDr0Vk8WwnohC/fCC3puXb5qJqfJwLVJLEtdTc6vK7ri/hw+Nn4wyT4LkZaPnvGfQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-6.1.1.tgz",
+      "integrity": "sha512-Q1Ika0F9MNhMtCs62Ue+GWIJtRFEhZ3Xz8wH7/MZDVZTWhil1/H2bEGN02kUees3hkI3q1oHSjmXYDM0gxaFjQ==",
       "requires": {
         "bs58": "^4.0.1",
         "class-is": "^1.1.0",
@@ -5762,11 +6203,11 @@
       }
     },
     "multiaddr-to-uri": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-4.0.1.tgz",
-      "integrity": "sha512-RVHKm5NXcMWMIhrwF4B4Q34JtMXt1/2wgnDTnKRE+AGAiXfqFika0bIfCsAtLp+gZJOWeDLeT1vR6P0gGyVAtg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-5.0.0.tgz",
+      "integrity": "sha512-aVc52fdGXso3DwvVKUTjMddhLyuFBXcpGSbsIju0lKiYKFBUEREXSLpcqTOZlO8w1G1TivVmDe4CBUKQ/xMm5A==",
       "requires": {
-        "multiaddr": "^6.0.3"
+        "multiaddr": "^6.1.0"
       }
     },
     "multibase": {
@@ -5871,14 +6312,14 @@
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
     },
     "nanoid": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.0.3.tgz",
-      "integrity": "sha512-NbaoqdhIYmY6FXDRB4eYtDVC9Z9eCbn8TyaiC16LNKtpPv/aqa0tOPD8y6gNE4yUNnaZ7LLhYtXOev/6+cBtfw=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.2.tgz",
+      "integrity": "sha512-q0iKJHcLc9rZg/qtJ/ioG5s6/5357bqvkYCpqXJxpcyfK7L5us8+uJllZosqPWou7l6E1lY2Qqoq5ce+AMbFuQ=="
     },
     "napi-macros": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-1.8.2.tgz",
-      "integrity": "sha512-Tr0DNY4RzTaBG2W2m3l7ZtFuJChTH6VZhXVhkGGjF/4cZTt+i8GcM9ozD+30Lmr4mDoZ5Xx34t2o4GJqYWDGcg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
+      "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -5907,20 +6348,32 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "nise": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.2.tgz",
+      "integrity": "sha512-/6RhOUlicRCbE9s+94qCUsyE+pKlVJ5AhIv+jEE7ESKwnbXqulKZ1FYU+XAtHHWE9TinYvAxDUJAb912PwPoWA==",
+      "requires": {
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "lolex": "^4.1.0",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
     "node-fetch": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
       "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "node-forge": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
-      "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+      "integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q=="
     },
     "node-gyp-build": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.1.0.tgz",
-      "integrity": "sha512-rGLv++nK20BG8gc0MzzcYe1Nl3p3mtwJ74Q2QD0HTEDKZ6NvOFSelY6s2QBPWIHRR8h7hpad0LiwajfClBJfNg=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.1.1.tgz",
+      "integrity": "sha512-dSq1xmcPDKPZ2EED2S6zw/b9NKsqzXRE6dVr8TVQnI3FJOTteUMuqF3Qqs6LZg+mLGYJWqQzMbIjMtJqTv87nQ=="
     },
     "nodeify": {
       "version": "1.0.1",
@@ -5950,9 +6403,9 @@
       }
     },
     "normalize-url": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.3.0.tgz",
-      "integrity": "sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ=="
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
     },
     "npm-run-path": {
       "version": "2.0.2",
@@ -5972,10 +6425,16 @@
       "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
       "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
     },
+    "object-inspect": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+      "dev": true
+    },
     "object-keys": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-      "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object.assign": {
       "version": "4.1.0",
@@ -5987,14 +6446,6 @@
         "function-bind": "^1.1.1",
         "has-symbols": "^1.0.0",
         "object-keys": "^1.0.11"
-      },
-      "dependencies": {
-        "object-keys": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-          "dev": true
-        }
       }
     },
     "object.entries": {
@@ -6010,15 +6461,35 @@
       }
     },
     "object.fromentries": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.0.tgz",
-      "integrity": "sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.1.tgz",
+      "integrity": "sha512-PUQv8Hbg3j2QX0IQYv3iAGCbGcu4yY4KQ92/dhA4sFSixBmSmp13UpDLs6jGK8rBtbmhNNIK99LD2k293jpiGA==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.11.0",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.15.0",
         "function-bind": "^1.1.1",
-        "has": "^1.0.1"
+        "has": "^1.0.3"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.15.0.tgz",
+          "integrity": "sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.0",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.0",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.6.0",
+            "object-keys": "^1.1.1",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "object.values": {
@@ -6047,11 +6518,11 @@
       }
     },
     "onetime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+      "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "^2.1.0"
       }
     },
     "opencollective-postinstall": {
@@ -6101,14 +6572,15 @@
       "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
     },
     "ora": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-3.4.0.tgz",
-      "integrity": "sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-4.0.2.tgz",
+      "integrity": "sha512-YUOZbamht5mfLxPmk4M35CD/5DuOkAacxlEUbStVXpBAt4fyhBf+vZHI/HRkI++QUp3sNoeA2Gw4C+hi4eGSig==",
       "requires": {
         "chalk": "^2.4.2",
-        "cli-cursor": "^2.1.0",
-        "cli-spinners": "^2.0.0",
-        "log-symbols": "^2.2.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.2.0",
+        "is-interactive": "^1.0.0",
+        "log-symbols": "^3.0.0",
         "strip-ansi": "^5.2.0",
         "wcwidth": "^1.0.1"
       }
@@ -6124,15 +6596,29 @@
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
       "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
     },
+    "p-defer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
+    },
+    "p-fifo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-fifo/-/p-fifo-1.0.0.tgz",
+      "integrity": "sha512-IjoCxXW48tqdtDFz6fqo5q1UfFVjjVZe8TC1QRflvNUJtNfCUhxOUw6MOVZhDPjqhSzc26xKdugsO17gmzd5+A==",
+      "requires": {
+        "fast-fifo": "^1.0.0",
+        "p-defer": "^3.0.0"
+      }
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-      "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+      "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
       "requires": {
         "p-try": "^2.0.0"
       }
@@ -6151,17 +6637,18 @@
       "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
     },
     "p-queue": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-5.0.0.tgz",
-      "integrity": "sha512-6QfeouDf236N+MAxHch0CVIy8o/KBnmhttKjxZoOkUlzqU+u9rZgEyXH3OdckhTgawbqf5rpzmyR+07+Lv0+zg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.1.1.tgz",
+      "integrity": "sha512-R9gq36Th88xZ+rWAptN5IXLwqkwA1gagCQhT6ZXQ6RxEfmjb9ZW+UBzRVqv9sm5TQmbbI/TsKgGLbOaA61xR5w==",
       "requires": {
-        "eventemitter3": "^3.1.0"
+        "eventemitter3": "^4.0.0",
+        "p-timeout": "^3.1.0"
       }
     },
     "p-timeout": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.1.0.tgz",
-      "integrity": "sha512-C27DYI+tCroT8J8cTEyySGydl2B7FlxrGNF5/wmMbl1V+jeehUCzEE/BVgzRebdm2K3ZitKOKx8YbdFumDyYmw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
       "requires": {
         "p-finally": "^1.0.0"
       }
@@ -6197,6 +6684,15 @@
       "dev": true,
       "requires": {
         "callsites": "^3.0.0"
+      }
+    },
+    "parse-headers": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.2.tgz",
+      "integrity": "sha512-/LypJhzFmyBIDYP9aDVgeyEb5sQfbfY5mnDq4hVhlQ69js87wXfmEI5V3xI6vvXasqebp0oCytYFLxsBVfCzSg==",
+      "requires": {
+        "for-each": "^0.3.3",
+        "string.prototype.trim": "^1.1.2"
       }
     },
     "parse-json": {
@@ -6249,6 +6745,21 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        }
+      }
+    },
     "path-type": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
@@ -6268,9 +6779,9 @@
       }
     },
     "peer-id": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.12.4.tgz",
-      "integrity": "sha512-AIAwL/6CmVc/VKbUhpA1rY3A/VJ3Z9ELvtvDQfl5cIi0A74L7lvsJ6LxQn5JSJVHM5Us2Ng9zMO523dO3FFnnw==",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.12.5.tgz",
+      "integrity": "sha512-3xVWrtIvNm9/OPzaQBgXDrfWNx63AftgFQkvqO6YSZy7sP3Fuadwwbn54F/VO9AnpyW/26i0WRQz9FScivXrmw==",
       "requires": {
         "async": "^2.6.3",
         "class-is": "^1.1.0",
@@ -6303,12 +6814,12 @@
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
     },
     "pino": {
-      "version": "5.13.1",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-5.13.1.tgz",
-      "integrity": "sha512-IxusG28L0g50uuf21kZELypdFOeNrJ/kRhktdi7LtdZQWCxLliMxG5iOrGUQ/ng7MiJ4XqXi/hfyXwZeKc1MxA==",
+      "version": "5.13.4",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-5.13.4.tgz",
+      "integrity": "sha512-heeg8m8FZY8Nl3nuuD+msJUmhamqoGl7JXoTExh9YpGajzz6LYbVByUqrjbf4sCEMYFsqdcqnTJWiSY660DraQ==",
       "requires": {
-        "fast-redact": "^1.4.4",
-        "fast-safe-stringify": "^2.0.6",
+        "fast-redact": "^2.0.0",
+        "fast-safe-stringify": "^2.0.7",
         "flatstr": "^1.0.9",
         "pino-std-serializers": "^2.3.0",
         "quick-format-unescaped": "^3.0.2",
@@ -6316,19 +6827,19 @@
       }
     },
     "pino-pretty": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-2.6.1.tgz",
-      "integrity": "sha512-e/CWtKLidqkr7sinfIVVcsfcHgnFVlGvuEfKuuPFnxBo+9dZZsmgF8a9Rj7SYJ5LMZ8YBxNY9Ca46eam4ajKtQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-3.2.1.tgz",
+      "integrity": "sha512-PGdcRYw7HCF7ovMhrnepOUmEVh5+tATydRrBICEbP37oRasXV+lo2HA9gg8b7cE7LG6G1OZGVXTZ7MLd946k1Q==",
       "requires": {
-        "args": "^5.0.0",
-        "chalk": "^2.3.2",
+        "@hapi/bourne": "^1.3.2",
+        "args": "^5.0.1",
+        "chalk": "^2.4.2",
         "dateformat": "^3.0.3",
-        "fast-json-parse": "^1.0.3",
         "fast-safe-stringify": "^2.0.6",
         "jmespath": "^0.15.0",
         "pump": "^3.0.0",
-        "readable-stream": "^3.0.6",
-        "split2": "^3.0.0"
+        "readable-stream": "^3.3.0",
+        "split2": "^3.1.1"
       }
     },
     "pino-std-serializers": {
@@ -6489,6 +7000,11 @@
       "requires": {
         "is-promise": "~1"
       }
+    },
+    "promise-nodeify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/promise-nodeify/-/promise-nodeify-3.0.1.tgz",
+      "integrity": "sha512-ghsSuzZXJX8iO7WVec2z7GI+Xk/EyiD+JZK7AZKhUqYfpLa/Zs4ylUD+CwwnKlG6G3HnkUPMAi6PO7zeqGKssg=="
     },
     "promise-timeout": {
       "version": "1.3.0",
@@ -6678,9 +7194,9 @@
       }
     },
     "pull-split": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/pull-split/-/pull-split-0.2.0.tgz",
-      "integrity": "sha1-mW0ohTEFIgmoMTiK0NKB3zyCN5Y=",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/pull-split/-/pull-split-0.2.1.tgz",
+      "integrity": "sha512-lloBKx+ijuRNvxvhM/SMJQ0r9/0WBGcpCPv8I6MZuYl4D1heUF/eYQObnqVehhtTMYuMwboK7RdhMa4Wg3YB7w==",
       "requires": {
         "pull-through": "~1.0.6"
       }
@@ -6768,14 +7284,19 @@
       }
     },
     "qs": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.0.tgz",
+      "integrity": "sha512-27RP4UotQORTpmNQDX8BHPukOnBP3p1uUJY5UnDhaJB+rMt9iMsok724XL+UHU23bEFOHRMQ2ZhI99qOWUMGFA=="
+    },
+    "queue-microtask": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.1.2.tgz",
+      "integrity": "sha512-F9wwNePtXrzZenAB3ax0Y8TSKGvuB7Qw16J30hspEUTbfUM+H827XyN3rlpwhVmtm5wuZtbKIHjOnwDn7MUxWQ=="
     },
     "quick-format-unescaped": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.2.tgz",
-      "integrity": "sha512-FXTaCkwvpIlkdKeGDNgcq07SXWS383noQUuZjvdE1QcTt+eLuqof6/BDiEPqB59FWLie/l91+HtlJSw7iCViSA=="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.3.tgz",
+      "integrity": "sha512-dy1yjycmn9blucmJLXOfZDx1ikZJUi6E8bBZLnhPG5gBrVhHXx2xVyqqgKBubVNEXmx51dBACMHpoMQK/N/AXQ=="
     },
     "quick-lru": {
       "version": "1.1.0",
@@ -6816,6 +7337,13 @@
             "safe-buffer": "~5.1.1",
             "string_decoder": "~1.1.1",
             "util-deprecate": "~1.0.1"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            }
           }
         },
         "string_decoder": {
@@ -6824,6 +7352,13 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            }
           }
         }
       }
@@ -6848,9 +7383,9 @@
       }
     },
     "react-is": {
-      "version": "16.8.6",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
-      "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
+      "version": "16.10.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.2.tgz",
+      "integrity": "sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA==",
       "dev": true
     },
     "read-pkg": {
@@ -7000,11 +7535,11 @@
       }
     },
     "restore-cursor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
       "requires": {
-        "onetime": "^2.0.0",
+        "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
       }
     },
@@ -7092,18 +7627,18 @@
       "dev": true
     },
     "rxjs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
-      "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
+      "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -7112,9 +7647,9 @@
       "dev": true
     },
     "sanitize-filename": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.2.tgz",
-      "integrity": "sha512-cmTzND7RMxUB+f7gI+4+KAVHWEg0lfXvQJdko+FXDP5bNbGIdx4KMP5pX6lv5jfT9jSf6OBbjyxjFtZQwYA/ig==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
       "requires": {
         "truncate-utf8-bytes": "^1.0.0"
       }
@@ -7153,9 +7688,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
     },
@@ -7209,11 +7744,11 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "shortid": {
-      "version": "2.2.14",
-      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.14.tgz",
-      "integrity": "sha512-4UnZgr9gDdA1kaKj/38IiudfC3KHKhDc1zi/HSxd9FQDR0VLwH3/y79tZJLsVYPsJgIjeHjqIWaWVRJUj9qZOQ==",
+      "version": "2.2.15",
+      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.15.tgz",
+      "integrity": "sha512-5EaCy2mx2Jgc/Fdn9uuDuNIIfWBpzY4XIlhoqtXF6qsf+/+SGZ+FxDdX/ZsMZiWupIWNqAEmiNY4RC+LSmCeOw==",
       "requires": {
-        "nanoid": "^2.0.0"
+        "nanoid": "^2.1.0"
       }
     },
     "signal-exit": {
@@ -7230,15 +7765,29 @@
       }
     },
     "simple-peer": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-9.5.0.tgz",
-      "integrity": "sha512-3tROq3nBo/CIZI8PWlXGbAxQIlQF6KQ/zcd4lQ2pAC4+rPiV7E721hI22nTO54uw/nzb2HKbvmDtZ4Wr173+vA==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-9.6.0.tgz",
+      "integrity": "sha512-NYqSKPu75xhkZYKGJhCbLCG5kfBtDHf8U9ddk4EKFfYNU7XgIisov+V8wMbVVgyMCfn8pm8uOqQQmE50FPDFWA==",
       "requires": {
         "debug": "^4.0.1",
         "get-browser-rtc": "^1.0.0",
-        "inherits": "^2.0.1",
+        "queue-microtask": "^1.1.0",
         "randombytes": "^2.0.3",
         "readable-stream": "^3.4.0"
+      }
+    },
+    "sinon": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.5.0.tgz",
+      "integrity": "sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==",
+      "requires": {
+        "@sinonjs/commons": "^1.4.0",
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/samsam": "^3.3.3",
+        "diff": "^3.5.0",
+        "lolex": "^4.2.0",
+        "nise": "^1.5.2",
+        "supports-color": "^5.5.0"
       }
     },
     "slice-ansi": {
@@ -7258,16 +7807,16 @@
       "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw=="
     },
     "socket.io": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.2.0.tgz",
-      "integrity": "sha512-wxXrIuZ8AILcn+f1B4ez4hJTPG24iNgxBBDaJfT6MsyOhVYiTXWexGoPkd87ktJG8kQEcL/NBvRi64+9k4Kc0w==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.3.0.tgz",
+      "integrity": "sha512-2A892lrj0GcgR/9Qk81EaY2gYhCBxurV0PfmmESO6p27QPrUK1J3zdns+5QPqvUYK2q657nSj0guoIil9+7eFg==",
       "requires": {
         "debug": "~4.1.0",
-        "engine.io": "~3.3.1",
+        "engine.io": "~3.4.0",
         "has-binary2": "~1.0.2",
         "socket.io-adapter": "~1.1.0",
-        "socket.io-client": "2.2.0",
-        "socket.io-parser": "~3.3.0"
+        "socket.io-client": "2.3.0",
+        "socket.io-parser": "~3.4.0"
       }
     },
     "socket.io-adapter": {
@@ -7276,16 +7825,16 @@
       "integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs="
     },
     "socket.io-client": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.2.0.tgz",
-      "integrity": "sha512-56ZrkTDbdTLmBIyfFYesgOxsjcLnwAKoN4CiPyTVkMQj3zTUh0QAx3GbvIvLpFEOvQWu92yyWICxB0u7wkVbYA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.3.0.tgz",
+      "integrity": "sha512-cEQQf24gET3rfhxZ2jJ5xzAOo/xhZwK+mOqtGRg5IowZsMgwvHwnf/mCRapAAkadhM26y+iydgwsXGObBB5ZdA==",
       "requires": {
         "backo2": "1.0.2",
         "base64-arraybuffer": "0.1.5",
         "component-bind": "1.0.0",
         "component-emitter": "1.2.1",
-        "debug": "~3.1.0",
-        "engine.io-client": "~3.3.1",
+        "debug": "~4.1.0",
+        "engine.io-client": "~3.4.0",
         "has-binary2": "~1.0.2",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
@@ -7296,39 +7845,6 @@
         "to-array": "0.1.4"
       },
       "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
-      }
-    },
-    "socket.io-parser": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
-      "integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
-      "requires": {
-        "component-emitter": "1.2.1",
-        "debug": "~3.1.0",
-        "isarray": "2.0.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "isarray": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
@@ -7338,6 +7854,43 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "socket.io-parser": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
+          "integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
+          "requires": {
+            "component-emitter": "1.2.1",
+            "debug": "~3.1.0",
+            "isarray": "2.0.1"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        }
+      }
+    },
+    "socket.io-parser": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.4.0.tgz",
+      "integrity": "sha512-/G/VOI+3DBp0+DJKW4KesGnQkQPFmUCbA/oO2QGT6CWxU7hLGWqU3tyuzeSK/dqcyeHsQg1vTe9jiZI8GU9SCQ==",
+      "requires": {
+        "component-emitter": "1.2.1",
+        "debug": "~4.1.0",
+        "isarray": "2.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
         }
       }
     },
@@ -7363,9 +7916,9 @@
       }
     },
     "sonic-boom": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-0.7.5.tgz",
-      "integrity": "sha512-1pKrnAV6RfvntPnarY71tpthFTM3pWZWWQdghZY8ARjtDPGzG/inxqSuRwQY/7V1woUjfyxPb437zn4p5phgnQ==",
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-0.7.6.tgz",
+      "integrity": "sha512-k9E2QQ4zxuVRLDW+ZW6ISzJs3wlEorVdmM7ApDgor7wsGKSDG5YGHsGmgLY4XYh4DMlr/2ap2BWAE7yTFJtWnQ==",
       "requires": {
         "flatstr": "^1.0.12"
       }
@@ -7452,29 +8005,29 @@
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
     },
     "standard": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/standard/-/standard-13.1.0.tgz",
-      "integrity": "sha512-h3NaMzsa88+/xtjXCMvdn6EWWdlodsI/HvtsQF+EGwrF9kVNwNha9TkFABU6bSBoNfC79YDyIAq9ekxOMBFkuw==",
+      "version": "14.3.1",
+      "resolved": "https://registry.npmjs.org/standard/-/standard-14.3.1.tgz",
+      "integrity": "sha512-TUQwU7znlZLfgKH1Zwn/D84FitWZkUTfbxSiz/vFx+4c9GV+clSfG/qLiLZOlcdyzhw3oF5/pZydNjbNDfHPEw==",
       "dev": true,
       "requires": {
-        "eslint": "~6.1.0",
-        "eslint-config-standard": "13.0.1",
-        "eslint-config-standard-jsx": "7.0.0",
+        "eslint": "~6.4.0",
+        "eslint-config-standard": "14.1.0",
+        "eslint-config-standard-jsx": "8.1.0",
         "eslint-plugin-import": "~2.18.0",
-        "eslint-plugin-node": "~9.1.0",
+        "eslint-plugin-node": "~10.0.0",
         "eslint-plugin-promise": "~4.2.1",
         "eslint-plugin-react": "~7.14.2",
         "eslint-plugin-standard": "~4.0.0",
-        "standard-engine": "~11.0.1"
+        "standard-engine": "^12.0.0"
       }
     },
     "standard-engine": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-11.0.1.tgz",
-      "integrity": "sha512-WZQ5PpEDfRzPFk+H9xvKVQPQIxKnAQB2cb2Au4NyTCtdw5R0pyMBUZLbPXyFjnlhe8Ae+zfNrWU4m6H5b7cEAg==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-12.0.0.tgz",
+      "integrity": "sha512-gJIIRb0LpL7AHyGbN9+hJ4UJns37lxmNTnMGRLC8CFrzQ+oB/K60IQjKNgPBCB2VP60Ypm6f8DFXvhVWdBOO+g==",
       "dev": true,
       "requires": {
-        "deglob": "^3.0.0",
+        "deglob": "^4.0.0",
         "get-stdin": "^7.0.0",
         "minimist": "^1.1.0",
         "pkg-conf": "^3.1.0"
@@ -7497,11 +8050,6 @@
         "pull-stream": "^3.2.3"
       }
     },
-    "streamsearch": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
-    },
     "strftime": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.10.0.tgz",
@@ -7517,12 +8065,42 @@
         "strip-ansi": "^5.1.0"
       }
     },
-    "string_decoder": {
+    "string.prototype.trim": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
-      "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.0.tgz",
+      "integrity": "sha512-9EIjYD/WdlvLpn987+ctkLf0FfvBefOCuiEr2henD8X+7jfwPnyvTdmW8OJhj5p+M0/96mBdynLWkxUr+rHlpg==",
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.13.0",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+      "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+      "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "strip-ansi": {
@@ -7562,9 +8140,9 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "superstruct": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.6.1.tgz",
-      "integrity": "sha512-LDbOKL5sNbOJ00Q36iYRhSexKIptZje0/mhNznnz04wT9CmsPDZg/K/UV1dgYuCwNMuOBHTbVROZsGB9EhhK4w==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.6.2.tgz",
+      "integrity": "sha512-lvA97MFAJng3rfjcafT/zGTSWm6Tbpk++DP6It4Qg7oNaeM+2tdJMuVgGje21/bIpBEs6iQql1PJH6dKTjl4Ig==",
       "requires": {
         "clone-deep": "^2.0.1",
         "kind-of": "^6.0.1"
@@ -7579,9 +8157,9 @@
       }
     },
     "table": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.4.5.tgz",
-      "integrity": "sha512-oGa2Hl7CQjfoaogtrOHEJroOcYILTx7BZWLGsJIlzoWmB2zmguhNfPJZsWPKYek/MgCxfco54gEi31d1uN2hFA==",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
       "dev": true,
       "requires": {
         "ajv": "^6.10.2",
@@ -7732,6 +8310,11 @@
         "prelude-ls": "~1.1.2"
       }
     },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+    },
     "type-fest": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
@@ -7770,6 +8353,11 @@
       "requires": {
         "crypto-random-string": "^1.0.0"
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "update-notifier": {
       "version": "3.0.1",
@@ -7817,12 +8405,12 @@
       }
     },
     "ursa-optional": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/ursa-optional/-/ursa-optional-0.9.10.tgz",
-      "integrity": "sha512-RvEbhnxlggX4MXon7KQulTFiJQtLJZpSb9ZSa7ZTkOW0AzqiVTaLjI4vxaSzJBDH9dwZ3ltZadFiBaZslp6haA==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/ursa-optional/-/ursa-optional-0.10.1.tgz",
+      "integrity": "sha512-/pgpBXVJut57dHNrdGF+1/qXi+5B7JrlmZDWPSyoivEcbwFWRZJBJGkWb6ivknMBA3bnFA7lqsb6iHiFfp79QQ==",
       "requires": {
-        "bindings": "^1.3.0",
-        "nan": "^2.11.1"
+        "bindings": "^1.5.0",
+        "nan": "^2.14.0"
       }
     },
     "utf8-byte-length": {
@@ -7851,9 +8439,9 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
     },
     "v8-compile-cache": {
       "version": "2.1.0",
@@ -7884,9 +8472,9 @@
       }
     },
     "varuint-bitcoin": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.0.tgz",
-      "integrity": "sha512-jCEPG+COU/1Rp84neKTyDJQr478/hAfVp5xxYn09QEH0yBjbmPeMfuuQIrp+BUD83hybtYZKhr5elV3bvdV1bA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz",
+      "integrity": "sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==",
       "requires": {
         "safe-buffer": "^5.1.1"
       }
@@ -8024,6 +8612,11 @@
       "resolved": "https://registry.npmjs.org/xor-distance/-/xor-distance-2.0.0.tgz",
       "integrity": "sha512-AsAqZfPAuWx7qB/0kyRDUEvoU3QKsHWzHU9smFlkaiprEpGfJ/NBbLze2Uq0rdkxCxkNM9uOLvz/KoNBCbZiLQ=="
     },
+    "xsalsa20": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/xsalsa20/-/xsalsa20-1.0.2.tgz",
+      "integrity": "sha512-g1DFmZ5JJ9Qzvt4dMw6m9IydqoCSP381ucU5zm46Owbk3bwmqAr8eEJirOPc7PrXRn45drzOpAyDp8jsnoyXyw=="
+    },
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -8040,11 +8633,12 @@
       "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
     },
     "yargs": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
-      "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.0.0.tgz",
+      "integrity": "sha512-ssa5JuRjMeZEUjg7bEL99AwpitxU/zWGAGpdj0di41pOEmJti8NR6kyUIJBkR78DTYNPZOU08luUo0GTHuB+ow==",
       "requires": {
         "cliui": "^5.0.0",
+        "decamelize": "^1.2.0",
         "find-up": "^3.0.0",
         "get-caller-file": "^2.0.1",
         "require-directory": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A CLI to co-host websites published to IPFS",
   "main": "index.js",
   "scripts": {
-    "test": "say sorry && exit 1"
+    "test": "say sorry && exit 1",
+    "lint": "standard *.js"
   },
   "bin": {
     "ipfs-cohost": "./bin.js"
@@ -12,13 +13,13 @@
   "author": "olizilla",
   "license": "MIT",
   "dependencies": {
-    "ipfs": "^0.37.0",
-    "ipfs-provider": "^0.2.1",
+    "ipfs": "^0.38.0",
+    "ipfs-provider": "^0.2.2",
     "meow": "^5.0.0",
-    "ora": "^3.4.0",
+    "ora": "^4.0.2",
     "pretty-bytes": "^5.3.0"
   },
   "devDependencies": {
-    "standard": "^13.1.0"
+    "standard": "^14.3.1"
   }
 }


### PR DESCRIPTION
- Matches spec on: https://github.com/ipfs-shipyard/cohosting
- Should be released as 2.0.0.
- Flag `--no-pib` removed since we do not create pins anymore.
- Commands `add`, `ls`, `rm`, `sync` and `gc` added.
- No command is alias to `add`.

Also, exports utility functions that can be imported somewhere else such as `sync` that might be [used on IPFS Desktop](https://github.com/ipfs-shipyard/ipfs-desktop/pull/1171).

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>